### PR TITLE
Add support for responsive styles

### DIFF
--- a/packages/core/src/constants/media-sizes.ts
+++ b/packages/core/src/constants/media-sizes.ts
@@ -1,0 +1,34 @@
+export type Size = 'large' | 'medium' | 'small';
+export const sizeNames: Size[] = ['small', 'medium', 'large'];
+
+export const sizes = {
+  small: {
+    min: 320,
+    default: 321,
+    max: 640,
+  },
+  medium: {
+    min: 641,
+    default: 642,
+    max: 991,
+  },
+  large: {
+    min: 990,
+    default: 991,
+    max: 1200,
+  },
+  getWidthForSize(size: Size) {
+    return this[size].default;
+  },
+  getSizeForWidth(width: number) {
+    for (const size of sizeNames) {
+      const value = this[size];
+      if (width <= value.max) {
+        return size;
+      }
+    }
+    return 'large';
+  },
+};
+
+export const mediaQueryRegex = /@\s*?media\s*?\(\s*?max-width\s*?:\s*?(\d+)(px)\s*?\)\s*?/;

--- a/packages/core/src/generators/builder.ts
+++ b/packages/core/src/generators/builder.ts
@@ -164,7 +164,6 @@ export const blockToBuilder = (
       const mediaQueryMatch = ruleKey.match(mediaQueryRegex);
       if (mediaQueryMatch) {
         const [fullmatch, pixelSize] = mediaQueryMatch;
-        console.log('MEDIA QUERY MATCH: ', mediaQueryMatch);
         const sizeForWidth = sizes.getSizeForWidth(Number(pixelSize));
         const currentSizeStyles = responsiveStyles[sizeForWidth] || {};
         responsiveStyles[sizeForWidth] = {
@@ -174,7 +173,7 @@ export const blockToBuilder = (
       } else {
         responsiveStyles.large = {
           ...responsiveStyles.large,
-          ...cssRules[ruleKey],
+          [ruleKey]: cssRules[ruleKey],
         };
       }
     }

--- a/packages/core/src/generators/builder.ts
+++ b/packages/core/src/generators/builder.ts
@@ -7,6 +7,7 @@ import dedent from 'dedent';
 import { format } from 'prettier/standalone';
 import json5 from 'json5';
 import { isUpperCase } from '../helpers/is-upper-case';
+import { mediaQueryRegex, sizes } from '../constants/media-sizes';
 
 const builderBlockPrefixes = ['Amp', 'Core', 'Builder', 'Raw', 'Form'];
 const mapComponentName = (name: string) => {
@@ -148,12 +149,41 @@ export const blockToBuilder = (
     }
   }
 
+  const hasCss = !!json.bindings.css;
+  let responsiveStyles: {
+    large: Partial<CSSStyleDeclaration>;
+    medium?: Partial<CSSStyleDeclaration>;
+    small?: Partial<CSSStyleDeclaration>;
+  } = {
+    large: {},
+  };
+  if (hasCss) {
+    const cssRules = json5.parse(json.bindings.css as string);
+    const cssRuleKeys = Object.keys(cssRules);
+    for (const ruleKey of cssRuleKeys) {
+      const mediaQueryMatch = ruleKey.match(mediaQueryRegex);
+      if (mediaQueryMatch) {
+        const [fullmatch, pixelSize] = mediaQueryMatch;
+        console.log('MEDIA QUERY MATCH: ', mediaQueryMatch);
+        const sizeForWidth = sizes.getSizeForWidth(Number(pixelSize));
+        const currentSizeStyles = responsiveStyles[sizeForWidth] || {};
+        responsiveStyles[sizeForWidth] = {
+          ...currentSizeStyles,
+          ...cssRules[ruleKey],
+        };
+      } else {
+        responsiveStyles.large = {
+          ...responsiveStyles.large,
+          ...cssRules[ruleKey],
+        };
+      }
+    }
+  }
+
   return el({
     tagName: thisIsComponent ? undefined : json.name,
-    ...(json.bindings.css && {
-      responsiveStyles: {
-        large: json5.parse(json.bindings.css as string),
-      },
+    ...(hasCss && {
+      responsiveStyles,
     }),
     ...(thisIsComponent && {
       component: {

--- a/packages/core/src/parsers/builder.ts
+++ b/packages/core/src/parsers/builder.ts
@@ -4,7 +4,7 @@ import { last, omit, pickBy } from 'lodash';
 import { createJSXLiteComponent } from '../helpers/create-jsx-lite-component';
 import { createJSXLiteNode } from '../helpers/create-jsx-lite-node';
 import { JSXLiteNode } from '../types/jsx-lite-node';
-import { sizes, Size } from '../constants/media-sizes';
+import { sizes, Size, sizeNames } from '../constants/media-sizes';
 
 // Omit some superflous styles that can come from Builder's web importer
 const styleOmitList: (
@@ -195,34 +195,29 @@ export const builderElementToJsxLiteNode = (
     properties.builderTag = block.tagName;
   }
 
-  const sizeKeys = Object.keys(block.responsiveStyles || {});
-  const hasCss = Boolean(sizeKeys.length);
-  const css: { [key: string]: Partial<CSSStyleDeclaration> } = {};
-  if (hasCss) {
-    for (const size of sizeKeys) {
-      if (size === 'large') {
-        css.large = omit(
-          {
-            ...css.large,
-            ...block.responsiveStyles!.large,
-          },
-          styleOmitList,
-        );
-      } else if (
-        block.responsiveStyles &&
-        block.responsiveStyles[size as Size]
-      ) {
-        const mediaQueryKey = `@media (max-width: ${
-          sizes[size as Size].max
-        }px)`;
-        css[mediaQueryKey] = omit(
-          {
-            ...css[mediaQueryKey],
-            ...block.responsiveStyles[size as Size],
-          },
-          styleOmitList,
-        );
-      }
+  const blockSizes: Size[] = Object.keys(
+    block.responsiveStyles || {},
+  ).filter((size) => sizeNames.includes(size as Size)) as Size[];
+  const hasCss = Boolean(blockSizes.length);
+  let css: { [key: string]: Partial<CSSStyleDeclaration> } = {};
+  for (const size of blockSizes) {
+    if (size === 'large') {
+      css = omit(
+        {
+          ...css,
+          ...block.responsiveStyles?.large,
+        },
+        styleOmitList,
+      );
+    } else if (block.responsiveStyles && block.responsiveStyles[size]) {
+      const mediaQueryKey = `@media (max-width: ${sizes[size].max}px)`;
+      css[mediaQueryKey] = omit(
+        {
+          ...css[mediaQueryKey],
+          ...block.responsiveStyles[size],
+        },
+        styleOmitList,
+      );
     }
   }
 


### PR DESCRIPTION
This adds support for responsive styling. I decided to only support jsx-lite -> builder media queries that are `max-width` and pixel based, since when writing back to jsx-lite from builder we convert to that format.

e.g.
```
    <div
      css={{
        width: "100px",
        color: "red",
        "@media (max-width: 640px)": {
          width: "50px",
          color: "rgba(54, 70, 175, 1)",
        },
      }}
    > hello </div>
```


Keeping as a draft since it needs more testing!