### PR TITLE
Reorder JSX spreads and use `button` for Buttons

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -44,7 +44,9 @@ export default function MyComponent(props) {
 
       {Boolean(!props.link) && (
         <>
-          <span {...props.attributes}>{props.text}</span>
+          <button {...props.attributes} type=\\"button\\">
+            {props.text}
+          </button>
         </>
       )}
     </>
@@ -377,6 +379,22 @@ export default function MyComponent(props) {
         </>
       )}
     </form>
+  );
+}
+"
+`;
+
+exports[`React Image 1`] = `
+"export interface ImageProps {
+  alt?: string;
+  src?: string;
+}
+
+export default function MyComponent(props) {
+  return (
+    <picture>
+      <img {...props} />
+    </picture>
   );
 }
 "

--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -45,7 +45,9 @@ export default function MyComponent() {
       </Show>
 
       <Show when={!props.link}>
-        <span {...props.attributes}>{props.text}</span>
+        <button {...props.attributes} type=\\"button\\">
+          {props.text}
+        </button>
       </Show>
     </Fragment>
   );

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -30,7 +30,7 @@ exports[`Vue Button 1`] = `
     </template>
 
     <template v-if=\\"!link\\">
-      <span v-bind=\\"attributes\\">{text}</span>
+      <button v-bind=\\"attributes\\" type=\\"button\\">{text}</button>
     </template>
   </div>
 </template>

--- a/packages/core/src/__tests__/data/blocks/button.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/button.raw.tsx
@@ -12,15 +12,15 @@ export default function Button(props: ButtonProps) {
     <>
       <Show when={props.link}>
         <a
+          {...props.attributes}
           href={props.link}
           target={props.openLinkInNewTab ? '_blank' : undefined}
-          {...props.attributes}
         >
           {props.text}
         </a>
       </Show>
       <Show when={!props.link}>
-        <span {...props.attributes}>{props.text}</span>
+        <button {...props.attributes} type="button">{props.text}</button>
       </Show>
     </>
   );

--- a/packages/core/src/__tests__/data/blocks/select.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/select.raw.tsx
@@ -12,6 +12,7 @@ export interface FormSelectProps {
 export default function SelectComponent(props: FormSelectProps) {
   return (
     <select
+      {...props.attributes}
       value={props.value}
       key={
         Builder.isEditing && props.defaultValue
@@ -20,7 +21,6 @@ export default function SelectComponent(props: FormSelectProps) {
       }
       defaultValue={props.defaultValue}
       name={props.name}
-      {...props.attributes}
     >
       <For each={props.options}>
         {(option) => (


### PR DESCRIPTION
- Spreading `props.attributes` moved to the start so they don't stomp any explicit component prop
- The Button component was using a regular span, here we use a `button` HTML element