### PR TITLE
Vue Gen fixes + `innerHTML` support

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/liquid.test.ts.snap
@@ -68,6 +68,11 @@ exports[`Liquid Submit button block 1`] = `
 "
 `;
 
+exports[`Liquid Text 1`] = `
+"<div></div>
+"
+`;
+
 exports[`Liquid Textarea 1`] = `
 "<textarea
   placeholder=\\"{{placeholder}}\\"

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -550,6 +550,32 @@ export default function MyComponent(props) {
 "
 `;
 
+exports[`React Text 1`] = `
+"import { Builder } from \\"@builder.io/sdk\\";
+
+export interface TextProps {
+  attributes?: any;
+  rtlMode: boolean;
+  text?: string;
+  content?: string;
+  builderBlock?: any;
+}
+
+export default function MyComponent(props) {
+  return (
+    <>
+      <div
+        contentEditable={allowEditingText || undefined}
+        dangerouslySetInnerHTML={{
+          __html: \\"props.text || props.content || ''\\",
+        }}
+      ></div>
+    </>
+  );
+}
+"
+`;
+
 exports[`React Textarea 1`] = `
 "export interface TextareaProps {
   attributes?: any;

--- a/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react.test.ts.snap
@@ -418,9 +418,9 @@ export default function MyComponent(props) {
           objectFit: props.backgroundSize || \\"cover\\",
           objectPosition: props.backgroundPosition || \\"center\\",
         }}
-        key={(Builder.isEditing && imgSrc) || \\"default-key\\"}
+        key={(Builder.isEditing && props.imgSrc) || \\"default-key\\"}
         alt={props.altText}
-        src={imgSrc}
+        src={props.imgSrc}
       />
     </>
   );
@@ -477,9 +477,9 @@ export default function MyComponent(props) {
       <section
         {...props.attributes}
         style={
-          maxWidth && typeof maxWidth === \\"number\\"
+          props.maxWidth && typeof props.maxWidth === \\"number\\"
             ? {
-                maxWidth,
+                maxWidth: props.maxWidth,
               }
             : undefined
         }

--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -545,6 +545,32 @@ export default function MyComponent() {
 "
 `;
 
+exports[`Solid Text 1`] = `
+"import { createMutable, Show, For } from \\"solid-js\\";
+
+import { Builder } from \\"@builder.io/sdk\\";
+
+export interface TextProps {
+  attributes?: any;
+  rtlMode: boolean;
+  text?: string;
+  content?: string;
+  builderBlock?: any;
+}
+
+export default function MyComponent() {
+  const state = createMutable({});
+
+  return (
+    <div
+      contentEditable={allowEditingText || undefined}
+      innerHTML={props.text || props.content || \\"\\"}
+    ></div>
+  );
+}
+"
+`;
+
 exports[`Solid Textarea 1`] = `
 "import { createMutable, Show, For } from \\"solid-js\\";
 

--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -408,9 +408,9 @@ export default function MyComponent() {
         objectFit: props.backgroundSize || \\"cover\\",
         objectPosition: props.backgroundPosition || \\"center\\",
       }}
-      key={(Builder.isEditing && imgSrc) || \\"default-key\\"}
+      key={(Builder.isEditing && props.imgSrc) || \\"default-key\\"}
       alt={props.altText}
-      src={imgSrc}
+      src={props.imgSrc}
     />
   );
 }
@@ -471,9 +471,9 @@ export default function MyComponent() {
     <section
       {...props.attributes}
       style={
-        maxWidth && typeof maxWidth === \\"number\\"
+        props.maxWidth && typeof props.maxWidth === \\"number\\"
           ? {
-              maxWidth,
+              maxWidth: props.maxWidth,
             }
           : undefined
       }

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -4,7 +4,6 @@ exports[`Vue Basic 1`] = `
 "<template>
   <div>
     <input :value=\\"name\\" @change=\\"name = $event.target.value\\" />
-
     Hello! I can run in React, Vue, Solid, or Liquid!
   </div>
 </template>
@@ -25,12 +24,14 @@ exports[`Vue Button 1`] = `
         :href=\\"link\\"
         :target=\\"openLinkInNewTab ? '_blank' : undefined\\"
       >
-        {text}
+        {{ text }}
       </a>
     </template>
 
     <template v-if=\\"!link\\">
-      <button v-bind=\\"attributes\\" type=\\"button\\">{text}</button>
+      <button v-bind=\\"attributes\\" type=\\"button\\">
+        {{ text }}
+      </button>
     </template>
   </div>
 </template>
@@ -42,7 +43,9 @@ export interface ButtonProps {
   openLinkInNewTab?: boolean;
 }
 
-export default {};
+export default {
+  props: [\\"link\\", \\"attributes\\", \\"openLinkInNewTab\\", \\"text\\"],
+};
 </script>
 "
 `;
@@ -59,12 +62,12 @@ exports[`Vue Form block 1`] = `
     @submit=\\"onSubmit(event)\\"
   >
     <template v-if=\\"builderBlock && builderBlock.children\\">
-      <template v-for=\\"block in builderBlock?.children\\"
-        ><BuilderBlockComponent
+      <template v-for=\\"block in builderBlock?.children\\">
+        <BuilderBlockComponent
           :key=\\"block.id\\"
           :block=\\"block\\"
-        ></BuilderBlockComponent
-      ></template>
+        ></BuilderBlockComponent>
+      </template>
     </template>
 
     <template v-if=\\"submissionState === 'error'\\">
@@ -83,9 +86,7 @@ exports[`Vue Form block 1`] = `
 
     <template v-if=\\"submissionState === 'error' && responseData\\">
       <pre class=\\"builder-form-error-text pre-1\\">
-        
-{JSON.stringify(responseData, null, 2)}
-
+        {{ JSON.stringify(responseData, null, 2) }}
       </pre>
     </template>
 
@@ -129,6 +130,27 @@ export interface FormProps {
 export type FormState = \\"unsubmitted\\" | \\"sending\\" | \\"success\\" | \\"error\\";
 
 export default {
+  props: [
+    \\"previewState\\",
+    \\"sendWithJs\\",
+    \\"sendSubmissionsTo\\",
+    \\"action\\",
+    \\"customHeaders\\",
+    \\"contentType\\",
+    \\"sendSubmissionsToEmail\\",
+    \\"name\\",
+    \\"method\\",
+    \\"errorMessagePath\\",
+    \\"resetFormOnSubmit\\",
+    \\"successUrl\\",
+    \\"validate\\",
+    \\"attributes\\",
+    \\"builderBlock\\",
+    \\"errorMessage\\",
+    \\"sendingMessage\\",
+    \\"successMessage\\",
+  ],
+
   data: () => ({
     state: \\"unsubmitted\\",
     responseData: null,
@@ -405,6 +427,14 @@ export interface ImgProps {
 }
 
 export default {
+  props: [
+    \\"backgroundSize\\",
+    \\"backgroundPosition\\",
+    \\"attributes\\",
+    \\"imgSrc\\",
+    \\"altText\\",
+  ],
+
   data: () => ({ Builder }),
 };
 </script>
@@ -438,6 +468,16 @@ export interface FormInputProps {
 }
 
 export default {
+  props: [
+    \\"attributes\\",
+    \\"defaultValue\\",
+    \\"placeholder\\",
+    \\"type\\",
+    \\"name\\",
+    \\"value\\",
+    \\"required\\",
+  ],
+
   data: () => ({ Builder }),
 };
 </script>
@@ -451,7 +491,7 @@ exports[`Vue Section 1`] = `
     :style=\\"
       maxWidth && typeof maxWidth === 'number'
         ? {
-            maxWidth,
+            maxWidth: maxWidth,
           }
         : undefined
     \\"
@@ -466,7 +506,9 @@ export interface SectionProps {
   children?: any;
 }
 
-export default {};
+export default {
+  props: [\\"attributes\\", \\"maxWidth\\"],
+};
 </script>
 "
 `;
@@ -480,11 +522,9 @@ exports[`Vue Select block 1`] = `
     :defaultValue=\\"defaultValue\\"
     :name=\\"name\\"
   >
-    <template v-for=\\"option in options\\"
-      ><option :value=\\"option.value\\">
-        {option.name || option.value}
-      </option></template
-    >
+    <template v-for=\\"option in options\\">
+      <option :value=\\"option.value\\">{{ option.name || option.value }}</option>
+    </template>
   </select>
 </template>
 <script>
@@ -502,6 +542,8 @@ export interface FormSelectProps {
 }
 
 export default {
+  props: [\\"attributes\\", \\"value\\", \\"defaultValue\\", \\"name\\", \\"options\\"],
+
   data: () => ({ Builder }),
 };
 </script>
@@ -510,7 +552,9 @@ export default {
 
 exports[`Vue Submit button block 1`] = `
 "<template>
-  <button v-bind=\\"attributes\\" type=\\"submit\\">{text}</button>
+  <button v-bind=\\"attributes\\" type=\\"submit\\">
+    {{ text }}
+  </button>
 </template>
 <script>
 export interface ButtonProps {
@@ -518,7 +562,9 @@ export interface ButtonProps {
   text?: string;
 }
 
-export default {};
+export default {
+  props: [\\"attributes\\", \\"text\\"],
+};
 </script>
 "
 `;
@@ -542,7 +588,9 @@ export interface TextareaProps {
   placeholder?: string;
 }
 
-export default {};
+export default {
+  props: [\\"attributes\\", \\"placeholder\\", \\"name\\", \\"value\\", \\"defaultValue\\"],
+};
 </script>
 "
 `;
@@ -597,7 +645,19 @@ export interface VideoProps {
   lazyLoad?: boolean;
 }
 
-export default {};
+export default {
+  props: [
+    \\"attributes\\",
+    \\"fit\\",
+    \\"position\\",
+    \\"video\\",
+    \\"posterImage\\",
+    \\"autoPlay\\",
+    \\"muted\\",
+    \\"controls\\",
+    \\"loop\\",
+  ],
+};
 </script>
 "
 `;

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -569,6 +569,33 @@ export default {
 "
 `;
 
+exports[`Vue Text 1`] = `
+"<template>
+  <div
+    :contentEditable=\\"allowEditingText || undefined\\"
+    :v-html=\\"text || content || ''\\"
+  ></div>
+</template>
+<script>
+import { Builder } from \\"@builder.io/sdk\\";
+
+export interface TextProps {
+  attributes?: any;
+  rtlMode: boolean;
+  text?: string;
+  content?: string;
+  builderBlock?: any;
+}
+
+export default {
+  props: [\\"text\\", \\"content\\"],
+
+  data: () => ({ Builder }),
+};
+</script>
+"
+`;
+
 exports[`Vue Textarea 1`] = `
 "<template>
   <textarea

--- a/packages/core/src/__tests__/data/blocks/img.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/img.raw.tsx
@@ -18,7 +18,7 @@ export interface ImgProps {
     | 'bottom right';
 }
 
-export default function ImgComponent({ imgSrc, ...props }: ImgProps) {
+export default function ImgComponent(props: ImgProps) {
   return (
     <img
       style={{
@@ -26,9 +26,9 @@ export default function ImgComponent({ imgSrc, ...props }: ImgProps) {
         objectPosition: props.backgroundPosition || 'center',
       }}
       {...props.attributes}
-      key={(Builder.isEditing && imgSrc) || 'default-key'}
+      key={(Builder.isEditing && props.imgSrc) || 'default-key'}
       alt={props.altText}
-      src={imgSrc}
+      src={props.imgSrc}
     />
   );
 }

--- a/packages/core/src/__tests__/data/blocks/section.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/section.raw.tsx
@@ -11,7 +11,9 @@ export default function SectionComponent(props: SectionProps) {
     <section
       {...props.attributes}
       style={
-        props.maxWidth && typeof props.maxWidth === 'number' ? { maxWidth: props.maxWidth } : undefined
+        props.maxWidth && typeof props.maxWidth === 'number'
+          ? { maxWidth: props.maxWidth }
+          : undefined
       }
     >
       {props.children}

--- a/packages/core/src/__tests__/data/blocks/section.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/section.raw.tsx
@@ -6,12 +6,12 @@ export interface SectionProps {
   children?: any;
 }
 
-export default function SectionComponent({ maxWidth, ...props }: SectionProps) {
+export default function SectionComponent(props: SectionProps) {
   return (
     <section
       {...props.attributes}
       style={
-        maxWidth && typeof maxWidth === 'number' ? { maxWidth } : undefined
+        props.maxWidth && typeof props.maxWidth === 'number' ? { maxWidth: props.maxWidth } : undefined
       }
     >
       {props.children}

--- a/packages/core/src/__tests__/data/blocks/text.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/text.raw.tsx
@@ -1,0 +1,28 @@
+import { Builder } from '@builder.io/sdk';
+
+export interface TextProps {
+  attributes?: any;
+  rtlMode: boolean;
+  text?: string;
+  content?: string;
+  builderBlock?: any;
+}
+
+export default function Text(props: TextProps) {
+  const allowEditingText: boolean =
+    Builder.isBrowser &&
+    Builder.isEditing &&
+    location.search.includes('builder.allowTextEdit=true') &&
+    !(
+      props.builderBlock?.bindings?.['component.options.text'] ||
+      props.builderBlock?.bindings?.['options.text'] ||
+      props.builderBlock?.bindings?.['text']
+    );
+
+  return (
+    <div
+      contentEditable={allowEditingText || undefined}
+      innerHTML={props.text || props.content || ''}
+    />
+  );
+}

--- a/packages/core/src/__tests__/liquid.test.ts
+++ b/packages/core/src/__tests__/liquid.test.ts
@@ -10,6 +10,7 @@ const textarea = require('./data/blocks/textarea.raw');
 const img = require('./data/blocks/img.raw');
 const video = require('./data/blocks/video.raw');
 const section = require('./data/blocks/section.raw');
+const text = require('./data/blocks/text.raw');
 
 describe('Liquid', () => {
   test('Basic', () => {
@@ -68,6 +69,12 @@ describe('Liquid', () => {
 
   test('Section', () => {
     const json = parseJsx(section);
+    const output = componentToLiquid(json);
+    expect(output).toMatchSnapshot();
+  });
+
+  test('Text', () => {
+    const json = parseJsx(text);
     const output = componentToLiquid(json);
     expect(output).toMatchSnapshot();
   });

--- a/packages/core/src/__tests__/react.test.ts
+++ b/packages/core/src/__tests__/react.test.ts
@@ -10,6 +10,7 @@ const textarea = require('./data/blocks/textarea.raw');
 const img = require('./data/blocks/img.raw');
 const video = require('./data/blocks/video.raw');
 const section = require('./data/blocks/section.raw');
+const text = require('./data/blocks/text.raw');
 
 describe('React', () => {
   test('Basic', () => {
@@ -68,6 +69,12 @@ describe('React', () => {
 
   test('Section', () => {
     const json = parseJsx(section);
+    const output = componentToReact(json);
+    expect(output).toMatchSnapshot();
+  });
+
+  test('Text', () => {
+    const json = parseJsx(text);
     const output = componentToReact(json);
     expect(output).toMatchSnapshot();
   });

--- a/packages/core/src/__tests__/solid.test.ts
+++ b/packages/core/src/__tests__/solid.test.ts
@@ -10,6 +10,7 @@ const textarea = require('./data/blocks/textarea.raw');
 const img = require('./data/blocks/img.raw');
 const video = require('./data/blocks/video.raw');
 const section = require('./data/blocks/section.raw');
+const text = require('./data/blocks/text.raw');
 
 describe('Solid', () => {
   test('Basic', () => {
@@ -68,6 +69,12 @@ describe('Solid', () => {
 
   test('Section', () => {
     const json = parseJsx(section);
+    const output = componentToSolid(json);
+    expect(output).toMatchSnapshot();
+  });
+
+  test('Text', () => {
+    const json = parseJsx(text);
     const output = componentToSolid(json);
     expect(output).toMatchSnapshot();
   });

--- a/packages/core/src/__tests__/vue.test.ts
+++ b/packages/core/src/__tests__/vue.test.ts
@@ -10,6 +10,7 @@ const textarea = require('./data/blocks/textarea.raw');
 const img = require('./data/blocks/img.raw');
 const video = require('./data/blocks/video.raw');
 const section = require('./data/blocks/section.raw');
+const text = require('./data/blocks/text.raw');
 
 describe('Vue', () => {
   test('Basic', () => {
@@ -68,6 +69,12 @@ describe('Vue', () => {
 
   test('Section', () => {
     const json = parseJsx(section);
+    const output = componentToVue(json);
+    expect(output).toMatchSnapshot();
+  });
+
+  test('Text', () => {
+    const json = parseJsx(text);
     const output = componentToVue(json);
     expect(output).toMatchSnapshot();
   });

--- a/packages/core/src/generators/react.ts
+++ b/packages/core/src/generators/react.ts
@@ -31,7 +31,6 @@ import {
   runPreJsonPlugins,
 } from '../modules/plugins';
 import { capitalize } from '../helpers/capitalize';
-import { JSXLiteStyles } from 'src/types/jsx-lite-styles';
 
 type ToReactOptions = {
   prettier?: boolean;
@@ -40,19 +39,47 @@ type ToReactOptions = {
   plugins?: Plugin[];
 };
 
-const mappers: {
+const NODE_MAPPERS: {
   [key: string]: (json: JSXLiteNode, options: ToReactOptions) => string;
 } = {
-  Fragment: (json, options) => {
+  Fragment(json, options) {
     return `<>${json.children
       .map((item) => blockToReact(item, options))
       .join('\n')}</>`;
   },
+  For(json, options) {
+    return `{${processBinding(json.bindings.each as string, options)}.map(${
+      json.bindings._forName
+    } => (
+      <>${json.children
+        .filter(filterEmptyTextNodes)
+        .map((item) => blockToReact(item, options))
+        .join('\n')}</>
+    ))}`;
+  },
+  Show(json, options) {
+    return `{Boolean(${processBinding(
+      json.bindings.when as string,
+      options,
+    )}) && (
+      <>${json.children
+        .filter(filterEmptyTextNodes)
+        .map((item) => blockToReact(item, options))
+        .join('\n')}</>
+    )}`;
+  },
+};
+
+// TODO: Maybe in the future allow defining `string | function` as values
+const BINDING_MAPPERS: { [key: string]: string | ((key: string, value: string) => [newKey: string, newValue: string]) } = {
+  innerHTML(_key, value) {
+    return ['dangerouslySetInnerHTML', JSON.stringify({ __html: value })]
+  },
 };
 
 const blockToReact = (json: JSXLiteNode, options: ToReactOptions) => {
-  if (mappers[json.name]) {
-    return mappers[json.name](json, options);
+  if (NODE_MAPPERS[json.name]) {
+    return NODE_MAPPERS[json.name](json, options);
   }
 
   if (json.properties._text) {
@@ -64,64 +91,53 @@ const blockToReact = (json: JSXLiteNode, options: ToReactOptions) => {
 
   let str = '';
 
-  const children = json.children.filter(filterEmptyTextNodes);
+  str += `<${json.name} `;
 
-  if (json.name === 'For') {
-    str += `{${processBinding(json.bindings.each as string, options)}.map(${
-      json.bindings._forName
-    } => (
-      <>${children.map((item) => blockToReact(item, options)).join('\n')}</>
-    ))}`;
-  } else if (json.name === 'Show') {
-    str += `{Boolean(${processBinding(
-      json.bindings.when as string,
+  if (json.bindings._spread) {
+    str += ` {...(${processBinding(
+      json.bindings._spread as string,
       options,
-    )}) && (
-      <>${children.map((item) => blockToReact(item, options)).join('\n')}</>
-    )}`;
-  } else {
-    str += `<${json.name} `;
-
-    if (json.bindings._spread) {
-      str += ` {...(${processBinding(
-        json.bindings._spread as string,
-        options,
-      )})} `;
-    }
-
-    for (const key in json.properties) {
-      const value = json.properties[key];
-      str += ` ${key}="${(value as string).replace(/"/g, '&quot;')}" `;
-    }
-    for (const key in json.bindings) {
-      const value = json.bindings[key] as string;
-      if (key === '_spread') {
-        continue;
-      }
-      if (key === 'css' && value.trim() === '{}') {
-        continue;
-      }
-
-      if (key.startsWith('on')) {
-        str += ` ${key}={event => (${processBinding(value, options)})} `;
-      } else {
-        str += ` ${key}={${processBinding(value, options)}} `;
-      }
-    }
-    if (selfClosingTags.has(json.name)) {
-      return str + ' />';
-    }
-    str += '>';
-    if (json.children) {
-      str += json.children
-        .map((item) => blockToReact(item, options))
-        .join('\n');
-    }
-
-    str += `</${json.name}>`;
+    )})} `;
   }
 
-  return str;
+  for (const key in json.properties) {
+    const value = json.properties[key];
+    str += ` ${key}="${(value as string).replace(/"/g, '&quot;')}" `;
+  }
+
+  for (const key in json.bindings) {
+    const value = json.bindings[key] as string;
+    if (key === '_spread') {
+      continue;
+    }
+    if (key === 'css' && value.trim() === '{}') {
+      continue;
+    }
+
+    const useBindingValue = processBinding(value, options);
+    if (key.startsWith('on')) {
+      str += ` ${key}={event => (${useBindingValue})} `;
+    } else if (BINDING_MAPPERS[key]) {
+      const mapper = BINDING_MAPPERS[key];
+      if (typeof mapper === 'function') {
+        const [newKey, newValue] = mapper(key, useBindingValue);
+        str += ` ${newKey}={${newValue}} `;
+      } else {
+        str += ` ${BINDING_MAPPERS[key]}={${useBindingValue}} `;
+      }
+    } else {
+      str += ` ${key}={${useBindingValue}} `;
+    }
+  }
+  if (selfClosingTags.has(json.name)) {
+    return str + ' />';
+  }
+  str += '>';
+  if (json.children) {
+    str += json.children.map((item) => blockToReact(item, options)).join('\n');
+  }
+
+  return str + `</${json.name}>`;
 };
 
 const getRefsString = (json: JSXLiteComponent, refs = getRefs(json)) => {

--- a/packages/core/src/generators/react.ts
+++ b/packages/core/src/generators/react.ts
@@ -71,9 +71,11 @@ const NODE_MAPPERS: {
 };
 
 // TODO: Maybe in the future allow defining `string | function` as values
-const BINDING_MAPPERS: { [key: string]: string | ((key: string, value: string) => [newKey: string, newValue: string]) } = {
+const BINDING_MAPPERS: {
+  [key: string]: string | ((key: string, value: string) => [string, string]);
+} = {
   innerHTML(_key, value) {
-    return ['dangerouslySetInnerHTML', JSON.stringify({ __html: value })]
+    return ['dangerouslySetInnerHTML', JSON.stringify({ __html: value })];
   },
 };
 

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -103,7 +103,7 @@ export const blockToVue = (
     } else if (key === 'ref') {
       str += ` ref="${useValue}" `;
     } else if (BINDING_MAPPERS[key]) {
-      str += ` ${BINDING_MAPPERS[key]}=${useValue} `;
+      str += ` :${BINDING_MAPPERS[key]}="${useValue}" `;
     } else {
       str += ` :${key}="${useValue}" `;
     }

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -99,8 +99,7 @@ export const blockToVue = (
     if (key.startsWith('on')) {
       const event = key.replace('on', '').toLowerCase();
       // TODO: proper babel transform to replace. Util for this
-      const finalValue = useValue.replace(/event\./g, '$event.');
-      str += ` @${event}="${finalValue}" `;
+      str += ` @${event}="${useValue.replace(/event\./g, '$event.')}" `;
     } else if (key === 'ref') {
       str += ` ref="${useValue}" `;
     } else if (BINDING_MAPPERS[key]) {
@@ -183,7 +182,11 @@ export const componentToVue = (
       ${renderPreComponent(component)}
 
       export default {
-        ${elementProps.size ? `props: ${JSON.stringify(Array.from(elementProps))},` : ''}
+        ${
+          elementProps.size
+            ? `props: ${JSON.stringify(Array.from(elementProps))},`
+            : ''
+        }
         ${
           dataString.length < 4
             ? ''

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -24,7 +24,7 @@ export type ToVueOptions = {
   plugins?: Plugin[];
 };
 
-const mappers: {
+const NODE_MAPPERS: {
   [key: string]: (json: JSXLiteNode, options: ToVueOptions) => string;
 } = {
   Fragment(json, options) {
@@ -48,12 +48,17 @@ const mappers: {
   },
 };
 
+// TODO: Maybe in the future allow defining `string | function` as values
+const BINDING_MAPPERS: { [key: string]: string } = {
+  innerHTML: 'v-html',
+};
+
 export const blockToVue = (
   node: JSXLiteNode,
   options: ToVueOptions = {},
 ): string => {
-  if (mappers[node.name]) {
-    return mappers[node.name](node, options);
+  if (NODE_MAPPERS[node.name]) {
+    return NODE_MAPPERS[node.name](node, options);
   }
 
   if (isChildren(node)) {
@@ -98,6 +103,8 @@ export const blockToVue = (
       str += ` @${event}="${finalValue}" `;
     } else if (key === 'ref') {
       str += ` ref="${useValue}" `;
+    } else if (BINDING_MAPPERS[key]) {
+      str += ` ${BINDING_MAPPERS[key]}=${useValue} `;
     } else {
       str += ` :${key}="${useValue}" `;
     }

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -184,7 +184,7 @@ export const componentToVue = (
       export default {
         ${
           elementProps.size
-            ? `props: ${JSON.stringify(Array.from(elementProps))},`
+            ? `props: ${JSON.stringify(Array.from(elementProps).filter(prop => prop !== 'children'))},`
             : ''
         }
         ${

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -6,6 +6,7 @@ import { getStateObjectString } from '../helpers/get-state-object-string';
 import { mapRefs } from '../helpers/map-refs';
 import { renderPreComponent } from '../helpers/render-imports';
 import { stripStateAndPropsRefs } from '../helpers/strip-state-and-props-refs';
+import { getProps } from '../helpers/get-props';
 import { selfClosingTags } from '../parsers/jsx';
 import { JSXLiteComponent } from '../types/jsx-lite-component';
 import { JSXLiteNode } from '../types/jsx-lite-node';
@@ -26,116 +27,119 @@ export type ToVueOptions = {
 const mappers: {
   [key: string]: (json: JSXLiteNode, options: ToVueOptions) => string;
 } = {
-  Fragment: (json, options) => {
+  Fragment(json, options) {
     return `<div>${json.children
       .map((item) => blockToVue(item, options))
       .join('\n')}</div>`;
   },
+  For(json, options) {
+    return `<template v-for="${
+      json.bindings._forName
+    } in ${stripStateAndPropsRefs(json.bindings.each as string)}">
+      ${json.children.map((item) => blockToVue(item, options)).join('\n')}
+    </template>`;
+  },
+  Show(json, options) {
+    return `<template v-if="${stripStateAndPropsRefs(
+      json.bindings.when as string,
+    )}">
+      ${json.children.map((item) => blockToVue(item, options)).join('\n')}
+    </template>`;
+  },
 };
 
 export const blockToVue = (
-  json: JSXLiteNode,
+  node: JSXLiteNode,
   options: ToVueOptions = {},
 ): string => {
-  if (mappers[json.name]) {
-    return mappers[json.name](json, options);
+  if (mappers[node.name]) {
+    return mappers[node.name](node, options);
   }
 
-  if (isChildren(json)) {
+  if (isChildren(node)) {
     return `<slot></slot>`;
   }
 
-  if (json.properties._text) {
-    return json.properties._text;
+  if (node.properties._text) {
+    return `${node.properties._text}`;
   }
 
-  if (json.bindings._text) {
-    return `{${stripStateAndPropsRefs(json.bindings._text as string)}}`;
+  if (node.bindings._text) {
+    return `{{${stripStateAndPropsRefs(node.bindings._text as string)}}}`;
   }
 
   let str = '';
 
-  if (json.name === 'For') {
-    str += `<template v-for="${
-      json.bindings._forName
-    } in ${stripStateAndPropsRefs(json.bindings.each as string)}">`;
-    str += json.children.map((item) => blockToVue(item, options)).join('\n');
-    str += `</template>`;
-  } else if (json.name === 'Show') {
-    str += `<template v-if="${stripStateAndPropsRefs(
-      json.bindings.when as string,
-    )}">`;
-    str += json.children.map((item) => blockToVue(item, options)).join('\n');
-    str += `</template>`;
-  } else {
-    str += `<${json.name} `;
+  str += `<${node.name} `;
 
-    if (json.bindings._spread) {
-      str += `v-bind="${stripStateAndPropsRefs(
-        json.bindings._spread as string,
-      )}"`;
-    }
-
-    for (const key in json.properties) {
-      const value = json.properties[key];
-      str += ` ${key}="${value}" `;
-    }
-    for (const key in json.bindings) {
-      if (key === '_spread') {
-        continue;
-      }
-      const value = json.bindings[key] as string;
-      // TODO: proper babel transform to replace. Util for this
-      const useValue = stripStateAndPropsRefs(value);
-
-      if (key.startsWith('on')) {
-        const event = key.replace('on', '').toLowerCase();
-        // TODO: proper babel transform to replace. Util for this
-        const finalValue = useValue.replace(/event\./g, '$event.');
-        str += ` @${event}="${finalValue}" `;
-      } else if (key === 'ref') {
-        str += ` ref="${useValue}" `;
-      } else {
-        str += ` :${key}="${useValue}" `;
-      }
-    }
-    if (selfClosingTags.has(json.name)) {
-      return str + ' />';
-    }
-    str += '>';
-    if (json.children) {
-      str += json.children.map((item) => blockToVue(item, options)).join('\n');
-    }
-
-    str += `</${json.name}>`;
+  if (node.bindings._spread) {
+    str += `v-bind="${stripStateAndPropsRefs(
+      node.bindings._spread as string,
+    )}"`;
   }
-  return str;
+
+  for (const key in node.properties) {
+    const value = node.properties[key];
+    str += ` ${key}="${value}" `;
+  }
+
+  for (const key in node.bindings) {
+    if (key === '_spread') {
+      continue;
+    }
+    const value = node.bindings[key] as string;
+    // TODO: proper babel transform to replace. Util for this
+    const useValue = stripStateAndPropsRefs(value);
+
+    if (key.startsWith('on')) {
+      const event = key.replace('on', '').toLowerCase();
+      // TODO: proper babel transform to replace. Util for this
+      const finalValue = useValue.replace(/event\./g, '$event.');
+      str += ` @${event}="${finalValue}" `;
+    } else if (key === 'ref') {
+      str += ` ref="${useValue}" `;
+    } else {
+      str += ` :${key}="${useValue}" `;
+    }
+  }
+
+  if (selfClosingTags.has(node.name)) {
+    return str + ' />';
+  }
+
+  str += '>';
+  if (node.children) {
+    str += node.children.map((item) => blockToVue(item, options)).join('');
+  }
+
+  return str + `</${node.name}>`;
 };
 
 export const componentToVue = (
-  componentJson: JSXLiteComponent,
+  component: JSXLiteComponent,
   options: ToVueOptions = {},
 ) => {
   // Make a copy we can safely mutate, similar to babel's toolchain
-  let json = fastClone(componentJson);
-  if (options.plugins) {
-    json = runPreJsonPlugins(json, options.plugins);
-  }
-
-  mapRefs(json, (refName) => `this.$refs.${refName}`);
+  component = fastClone(component);
 
   if (options.plugins) {
-    json = runPostJsonPlugins(json, options.plugins);
+    component = runPreJsonPlugins(component, options.plugins);
   }
-  const css = collectCss(json);
 
-  let dataString = getStateObjectString(json, {
+  mapRefs(component, (refName) => `this.$refs.${refName}`);
+
+  if (options.plugins) {
+    component = runPostJsonPlugins(component, options.plugins);
+  }
+  const css = collectCss(component);
+
+  let dataString = getStateObjectString(component, {
     data: true,
     functions: false,
     getters: false,
   });
 
-  const getterString = getStateObjectString(json, {
+  const getterString = getStateObjectString(component, {
     data: false,
     getters: true,
     functions: false,
@@ -144,7 +148,8 @@ export const componentToVue = (
         replaceWith: 'this.',
       }),
   });
-  const functionsString = getStateObjectString(json, {
+
+  const functionsString = getStateObjectString(component, {
     data: false,
     getters: false,
     functions: true,
@@ -155,20 +160,23 @@ export const componentToVue = (
   // Append refs to data as { foo, bar, etc }
   dataString = dataString.replace(
     /}$/,
-    `${json.imports
+    `${component.imports
       .map((thisImport) => Object.keys(thisImport.imports).join(','))
       .filter(Boolean)
       .join(',')}}`,
   );
 
+  const elementProps = getProps(component);
+
   let str = dedent`
     <template>
-      ${json.children.map((item) => blockToVue(item)).join('\n')}
+      ${component.children.map((item) => blockToVue(item)).join('\n')}
     </template>
     <script>
-      ${renderPreComponent(json)}
+      ${renderPreComponent(component)}
 
       export default {
+        ${elementProps.size ? `props: ${JSON.stringify(Array.from(elementProps))},` : ''}
         ${
           dataString.length < 4
             ? ''
@@ -204,7 +212,7 @@ export const componentToVue = (
   if (options.plugins) {
     str = runPreCodePlugins(str, options.plugins);
   }
-  if (options.prettier !== false) {
+  if (true || options.prettier !== false) {
     try {
       str = format(str, {
         parser: 'vue',

--- a/packages/core/src/generators/vue.ts
+++ b/packages/core/src/generators/vue.ts
@@ -184,7 +184,9 @@ export const componentToVue = (
       export default {
         ${
           elementProps.size
-            ? `props: ${JSON.stringify(Array.from(elementProps).filter(prop => prop !== 'children'))},`
+            ? `props: ${JSON.stringify(
+                Array.from(elementProps).filter((prop) => prop !== 'children'),
+              )},`
             : ''
         }
         ${

--- a/packages/core/src/helpers/collect-styles.ts
+++ b/packages/core/src/helpers/collect-styles.ts
@@ -20,7 +20,7 @@ export const nodeHasStyles = (node: JSXLiteNode) => {
 export const hasStyles = (component: JSXLiteComponent) => {
   let hasStyles = false;
 
-  traverse(component).forEach(function (item) {
+  traverse(component).forEach(function(item) {
     if (isJsxLiteNode(item)) {
       if (nodeHasStyles(item)) {
         hasStyles = true;
@@ -62,7 +62,7 @@ export const collectStyledComponents = (json: JSXLiteComponent): string => {
 
   const componentIndexes: { [className: string]: number | undefined } = {};
 
-  traverse(json).forEach(function (item) {
+  traverse(json).forEach(function(item) {
     if (isJsxLiteNode(item)) {
       if (nodeHasStyles(item)) {
         const value = json5.parse(item.bindings.css as string);
@@ -111,7 +111,7 @@ export const collectStyles = (
 
   const componentIndexes: { [className: string]: number | undefined } = {};
 
-  traverse(json).forEach(function (item) {
+  traverse(json).forEach(function(item) {
     if (isJsxLiteNode(item)) {
       if (nodeHasStyles(item)) {
         const value = json5.parse(item.bindings.css as string);
@@ -123,9 +123,8 @@ export const collectStyles = (
         const index = (componentIndexes[componentName] =
           (componentIndexes[componentName] || 0) + 1);
         const className = `${componentName}-${index}`;
-        item.properties[classProperty] = `${
-          item.properties[classProperty] || ''
-        } ${className}`
+        item.properties[classProperty] = `${item.properties[classProperty] ||
+          ''} ${className}`
           .trim()
           .replace(/\s{2,}/g, ' ');
 

--- a/packages/core/src/parsers/builder.ts
+++ b/packages/core/src/parsers/builder.ts
@@ -1,6 +1,6 @@
 import { BuilderContent, BuilderElement } from '@builder.io/sdk';
 import json5 from 'json5';
-import { last, mapKeys, omit, pickBy } from 'lodash';
+import { mapKeys, omit } from 'lodash';
 import { createJSXLiteComponent } from '../helpers/create-jsx-lite-component';
 import { createJSXLiteNode } from '../helpers/create-jsx-lite-node';
 import { JSXLiteNode } from '../types/jsx-lite-node';
@@ -27,7 +27,6 @@ const getCssFromBlock = (block: BuilderElement) => {
   const blockSizes: Size[] = Object.keys(
     block.responsiveStyles || {},
   ).filter((size) => sizeNames.includes(size as Size)) as Size[];
-  const hasCss = Boolean(blockSizes.length);
   let css: { [key: string]: Partial<CSSStyleDeclaration> } = {};
   for (const size of blockSizes) {
     if (size === 'large') {
@@ -37,7 +36,7 @@ const getCssFromBlock = (block: BuilderElement) => {
           ...block.responsiveStyles?.large,
         },
         styleOmitList,
-      );
+      ) as typeof css;
     } else if (block.responsiveStyles && block.responsiveStyles[size]) {
       const mediaQueryKey = `@media (max-width: ${sizes[size].max}px)`;
       css[mediaQueryKey] = omit(


### PR DESCRIPTION
* Vue: Fixing value interpolation and prop enumeration
    * This (for now at least) requires that the `props` param must not be destructured, otherwise members plucked from the props won't be recognized.
* Allow using `innerHTML` JSX-Lite prop (maps to React's `dangerouslySetInnerHTML` and Vue's `v-html`)
* Added the `Text` Builder block