### PR TITLE
RenderBlock and RenderContent drafts

### DIFF
--- a/packages/core/src/__tests__/data/blocks/builder-render-block.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/builder-render-block.raw.tsx
@@ -1,0 +1,85 @@
+import { BuilderElement } from '@builder.io/sdk';
+import {
+  useState,
+  useDynamicTag,
+  createContext,
+  Show,
+  onError,
+  useContext,
+  For,
+} from '@jsx-lite/core';
+import {
+  stringToFunction,
+  getBlockOptions, // TODO: migrate logic here
+  getEmotionCss, // TODO: migrate logic here
+} from '@builder.io/utils';
+
+type RenderBlockProps = {
+  block: BuilderElement;
+};
+
+export const BuilderContext = createContext();
+
+export function RenderBlock(props: RenderBlockProps) {
+  const state = useState({
+    error: false,
+    get useRepeat() {
+      return Boolean(
+        props.block.repeat?.collection &&
+          Array.isArray(stringToFunction(this.repeatArray)),
+      );
+    },
+    get repeatArray() {
+      return stringToFunction(props.block.repeat?.collection);
+    },
+    get itemName() {
+      const collectionPath = props.block.repeat?.collection;
+      const split = (collectionPath || '')
+        .trim()
+        .split('(')[0]
+        .trim()
+        .split('.');
+      const collectionName = split[split.length - 1];
+      const itemName =
+        props.block.repeat?.itemName ||
+        (collectionName ? collectionName + 'Item' : 'item');
+      return itemName;
+    },
+    get blockOptions() {
+      return getBlockOptions(props.block, context);
+    },
+    get emotionCss() {
+      return getEmotionCss(props.block, context);
+    },
+  });
+
+  const context = useContext();
+
+  const DynamicTag = useDynamicTag(() => {
+    return props.block.tagName || 'div';
+  });
+
+  onError(() => (state.error = true));
+
+  return (
+    <>
+      <Show when={state.error}>
+        Builder block error :( Check console for details
+      </Show>
+      <Show when={!state.error}>
+        <Show when={state.useRepeat}>
+          <For each={state.repeatArray}>
+            {(item, index) => (
+              <BuilderContext.Provider>
+                <DynamicTag {...state.blockOptions} />
+              </BuilderContext.Provider>
+            )}
+          </For>
+        </Show>
+        <Show when={!state.useRepeat}>
+          <DynamicTag {...state.blockOptions} />
+        </Show>
+      </Show>
+    </>
+  );
+}

--- a/packages/core/src/__tests__/data/blocks/builder-render-content.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/builder-render-content.raw.tsx
@@ -1,0 +1,44 @@
+import { Show, onMount, useState } from '@jsx-lite/core';
+import { BuilderContent, GetContentOptions } from '@builder.io/sdk';
+import { useBuilderData } from '@builder.io/jsx-lite';
+import { RenderBlock } from './builder-render-block.raw';
+import { For } from 'src/flow';
+
+type RenderContentProps = {
+  model: string;
+  options?: GetContentOptions;
+  content?: BuilderContent;
+  children: any;
+};
+
+export function RenderContent(props: RenderContentProps) {
+  const content: BuilderContent | undefined =
+    props.content || useBuilderData(props.model, props.options);
+  const state = useState({
+    get css() {
+      return '';
+    },
+  });
+
+  return (
+    <>
+      <Show when={!content}>{props.children}</Show>
+      <Show when={content}>
+        <div
+          data-builder-component={content!.name}
+          data-builder-content-id={content!.id}
+          data-builder-variation-id={content!.testVariationId || content!.id}
+        >
+          <Show when={state.css}>
+            <style innerHTML={state.css} />¸
+          </Show>
+          <Show when={content!.data!.blocks}>
+            <For each={content!.data!.blocks}>
+              {(block) => <RenderBlock block={block} />}
+            </For>
+          </Show>
+        </div>
+      </Show>
+    </>
+  );
+}

--- a/packages/core/src/__tests__/data/blocks/builder-render-content.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/builder-render-content.raw.tsx
@@ -9,6 +9,7 @@ type RenderContentProps = {
   options?: GetContentOptions;
   content?: BuilderContent;
   children: any;
+  contentLoaded?: (content: BuilderContent) => void;
 };
 
 export function RenderContent(props: RenderContentProps) {
@@ -45,7 +46,7 @@ export function RenderContent(props: RenderContentProps) {
           }
 
           if (props.contentLoaded) {
-            props.contentLoaded(content.data);
+            props.contentLoaded(content);
           }
 
           break;
@@ -61,7 +62,9 @@ export function RenderContent(props: RenderContentProps) {
   });
 
   afterUnmount(() => {
-    removeEventListener('message', state.onWindowMessage);
+    if (Builder.isEditing) {
+      removeEventListener('message', state.onWindowMessage);
+    }
   });
 
   return (
@@ -69,6 +72,7 @@ export function RenderContent(props: RenderContentProps) {
       <Show when={!content}>{props.children}</Show>
       <Show when={content}>
         <div
+          data-builder-model-name={props.model}
           data-builder-component={content!.name}
           data-builder-content-id={content!.id}
           data-builder-variation-id={content!.testVariationId || content!.id}

--- a/packages/core/src/__tests__/data/blocks/builder-render-content.raw.tsx
+++ b/packages/core/src/__tests__/data/blocks/builder-render-content.raw.tsx
@@ -38,9 +38,6 @@ export function RenderContent(props: RenderContentProps) {
             return;
           }
 
-          if (location.href.includes('builder.debug=true')) {
-            eval('debugger');
-          }
           for (const patch of patches) {
             applyPatchWithMinimalMutationChain(content.data, patch);
           }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,9 @@ export const useState = <T>(obj: T) => obj;
 export const useRef = () => null as any;
 export const useContext = () => null as any;
 export const createContext = () => null as any;
+export const onMount = (fn: () => any) => null as any;
+export const useDynamicTag = (fn: () => any) => null as any;
+export const onError = (fn: () => any) => null as any;
 
 export * from './parsers/jsx';
 export * from './parsers/builder';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export const useRef = () => null as any;
 export const useContext = () => null as any;
 export const createContext = () => null as any;
 export const onMount = (fn: () => any) => null as any;
+export const afterUnmount = (fn: () => any) => null as any;
 export const useDynamicTag = (fn: () => any) => null as any;
 export const onError = (fn: () => any) => null as any;
 


### PR DESCRIPTION
I think we can absolutely move all of the components into JSX lite

remaining features needing support to get there

- context support (medium)
- onUnmount hook (easy)
- useBuilderData custom async hook (medium)
- [emotion support](https://github.com/egoist/vue-emotion) (medium)
- [dynamic component support](https://vuejs.org/v2/guide/components.html#Dynamic-Components) (easy)
- move logic like stringToFunction, getBlockOptions, applyPatchWithMinimalMutationChain, and getEmotionCss from the react sdk to our utils package (medium)

cc @mandx for our todo list ^ :)