### PR TITLE
CLI Generator Options

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -68,6 +68,12 @@ OPTIONS
 		Overwrite existing files.
 	--list, -l
 		List available output formats.
+GENERATOR OPTIONS
+	--format=<format>
+	--prefix=<prefix>
+	--includeIds=<include_ids>
+	--styles=<library_or_method>
+	--state=<library_or_method>
 `.trim()
   )
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -36,6 +36,10 @@ OPTIONS
 		- svelte
 		- liquid
 		- angular
+	--list, -l
+		List available output formats.
+
+OUTPUT OPTIONS
 	--out=<file>, -o=<file>
 		Emit output to a single file
 	--out-dir=<dir>
@@ -66,8 +70,11 @@ OPTIONS
 		Perform a trial run with no changes made.
 	--force
 		Overwrite existing files.
-	--list, -l
-		List available output formats.
+	--header=<string>
+		Add a preamble to the document. Useful if you want to include a
+		license or an import statement. Header will be ignored if the
+		output is JSON.
+
 GENERATOR OPTIONS
 	--format=<format>
 	--prefix=<prefix>

--- a/packages/cli/src/commands/jsx-lite.ts
+++ b/packages/cli/src/commands/jsx-lite.ts
@@ -31,14 +31,16 @@ const command: GluegunCommand = {
     const dryRun = opts.dryRun ?? opts.n ?? false
     const outDir = opts.outDir
 
-    const generatorOpts: {[K in AllGeneratorOptionKeys]: any} = {
+    const header = opts.header
+
+    const generatorOpts: { [K in AllGeneratorOptionKeys]: any } = {
       prettier: true,
       plugins: [],
       format: opts.format,
       prefix: opts.prefix,
       includeIds: opts.includeIds,
       stylesType: opts.styles,
-      stateType: opts.state,
+      stateType: opts.state
     }
 
     // Positional Args
@@ -69,7 +71,8 @@ const command: GluegunCommand = {
 
     async function* readFiles() {
       if (isStdin) {
-        return { data: readStdin() }
+        const data = await readStdin()
+        return { data }
       }
       for (const path of paths) {
         if (filesystem.exists(path) !== 'file') {
@@ -111,8 +114,14 @@ const command: GluegunCommand = {
         print.info(inspect(data, true, 10, true))
       }
 
+      const isJSON = typeof output === 'object'
+
+      if (!isJSON) {
+        output = header ? `${header}\n${output}` : output
+      }
+
       if (!out) {
-        if (typeof output === 'object') {
+        if (isJSON) {
           console.log(JSON.stringify(output, null, 2))
           return
         }

--- a/packages/cli/src/commands/jsx-lite.ts
+++ b/packages/cli/src/commands/jsx-lite.ts
@@ -11,7 +11,7 @@ type GeneratorOpts = Parameters<Targets[Target]>[1]
 
 type AllGeneratorOption = UnionToIntersection<GeneratorOpts>
 // The only purpose this really serves is to ensure I provide a flag API
-// for ever generators options.
+// for ever generator's option.
 type AllGeneratorOptionKeys = keyof AllGeneratorOption
 
 const command: GluegunCommand = {

--- a/packages/cli/src/commands/jsx-lite.ts
+++ b/packages/cli/src/commands/jsx-lite.ts
@@ -1,4 +1,4 @@
-import * as core from '@jsx-lite/core'
+import { parseJsx } from '@jsx-lite/core'
 import { GluegunCommand } from 'gluegun'
 import { join } from 'path'
 import { inspect } from 'util'
@@ -100,7 +100,7 @@ const command: GluegunCommand = {
       }
 
       try {
-        const json = core.parseJsx(data)
+        const json = parseJsx(data)
         // TODO validate generator options
         output = generator(json, generatorOpts as any)
       } catch (e) {

--- a/packages/cli/src/targets.ts
+++ b/packages/cli/src/targets.ts
@@ -1,0 +1,15 @@
+export {
+  componentToAngular as angular,
+  componentToBuilder as builder,
+  componentToCustomElement as customElement,
+  componentToHtml as html,
+  componentToJsxLite as jsxLite,
+  componentToLiquid as liquid,
+  componentToReact as react,
+  componentToReactNative as reactNative,
+  componentToSolid as solid,
+  componentToSvelte as svelte,
+  componentToSwift as swift,
+  componentToTemplate as template,
+  componentToVue as vue
+} from '@jsx-lite/core'

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,1 +1,10 @@
-// export types
+export type UnionToIntersection<Union> =
+  // This basically just runs the next extends clause in a loop. The second
+  // extends clause pulls each member of the union out, and because
+  // they're implied to be a valid contract, they're merged into an
+  // intersection.
+  (Union extends any
+  ? (_: Union) => any
+  : never) extends (_: infer Intersection) => any
+    ? Intersection
+    : never


### PR DESCRIPTION
- Fix for JSON output
- Clean up cli target list
- Add support for generator options to cli
- Add header flag to cli

Sample output

```
✦ ❯ jsx-lite --to react ../core/src/__tests__/data/basic.raw.tsx --header "// Hello world" --state useState
// Hello world
import { useState } from "react";

export default function MyComponent(props) {
  const [name, setName] = useState(() => "Steve");

  return (
    <>
      <div>
        <input
          value={name}
          onChange={(event) => {
            setName(event.target.value);
          }}
        />
        Hello! I can run in React, Vue, Solid, or Liquid!
      </div>
    </>
  );
}
```
