### PR TITLE
Add gotchas to overview doc

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,6 +2,32 @@
 
 JSX Lite is a subset of [JSX](https://github.com/facebook/jsx). It supports generating code for a number of frontend frameworks, including React, Vue, Angular, Svelte, and Solid.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+**Table of contents**
+
+- [At a glance](#at-a-glance)
+- [Components](#components)
+- [Styling](#styling)
+- [State](#state)
+- [Methods](#methods)
+- [Control flow](#control-flow)
+  - [Show](#show)
+  - [For](#for)
+- [Refs](#refs)
+- [onMount](#onmount)
+- [onUnMount](#onunmount)
+- [Gotchas and limitations](#gotchas-and-limitations)
+  - [Defining variables with the same name as a state property will shadow it](#defining-variables-with-the-same-name-as-a-state-property-will-shadow-it)
+  - [Async methods can't be defined on "state"](#async-methods-cant-be-defined-on-state)
+  - [Callback implicitly have an "event" arg](#callback-implicitly-have-an-event-arg)
+  - [Functions can't be passed by reference to JSX callbacks](#functions-cant-be-passed-by-reference-to-jsx-callbacks)
+  - [Can't assign to "params" to "state"](#cant-assign-to-params-to-state)
+  - [Can't destructure assignment from state](#cant-destructure-assignment-from-state)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## At a glance
 
 JSX Lite is inspired by many modern frameworks. You'll see components look like React components and use React-like hooks, but have simple mutable state like Vue, use a static form of JSX like Solid, compile away like Svelte, and uses a simple, prescriptive structure like Angular.
@@ -9,7 +35,7 @@ JSX Lite is inspired by many modern frameworks. You'll see components look like 
 An example JSX Lite component showing several features:
 
 ```javascript
-import { useState, Show, For } from '@jsx-lite/core';
+import { For, Show, useState } from '@jsx-lite/core';
 
 export default function MyComponent(props) {
   const state = useState({
@@ -25,7 +51,9 @@ export default function MyComponent(props) {
       <Show when={props.showInput}>
         <input
           value={state.newItemName}
-          onChange={(event) => (state.newItemName = event.target.value)}
+          onChange={(
+            event,
+          ) => (state.newItemName = event.target.value)}
         />
       </Show>
       <div css={{ padding: '10px' }}>
@@ -219,5 +247,267 @@ export default function MyComponent() {
   });
 
   return <div>Hello world</div>;
+}
+```
+
+## Gotchas and limitations
+
+### Defining variables with the same name as a state property will shadow it
+
+_JSX Lite input_
+
+```typescript
+export default function MyComponent() {
+  const state = useState({
+    foo: 'bar',
+
+    doSomething() {
+      const foo = state.foo;
+    },
+  });
+}
+```
+
+_JSX Lite output_
+
+```typescript
+import { useState } from 'react';
+
+export default function MyComponent(props) {
+  const [foo, setFoo] = useState(() => 'bar');
+  function doSomething() {
+    const foo = foo;
+  }
+
+  return <></>;
+}
+```
+
+**Work around**
+
+Use a different variable name
+
+_JSX Lite input_
+
+```typescript
+export default function MyComponent() {
+  const state = useState({
+    foo: 'bar',
+
+    doSomething() {
+      const foo_ = state.foo;
+    },
+  });
+}
+```
+
+_JSX Lite output_
+
+```typescript
+import { useState } from 'react';
+
+export default function MyComponent(props) {
+  const [foo, setFoo] = useState(() => 'bar');
+  function doSomething() {
+    const foo_ = foo;
+  }
+
+  return <></>;
+}
+```
+
+### Async methods can't be defined on "state"
+
+_JSX Lite input_
+
+```typescript
+export default function MyComponent() {
+  const state = useState({
+    async doSomethingAsync(event) {
+      //  ^^^^^^^^^^^^^^^^^^^^^^^^^
+      //  Fails to parse this line
+      return;
+    },
+  });
+}
+```
+
+**Work around**
+
+You can either:
+
+a. Use promises in this context instead or
+b. Use an immediately invoked async function
+
+_JSX Lite input_
+
+```typescript
+export default function MyComponent() {
+  const state = useState({
+    doSomethingAsync(event) {
+      void async function() {
+        const response = await fetch(); /* ... */
+      }();
+    },
+  });
+}
+```
+
+_JSX Lite output_
+
+```typescript
+import { useState } from 'react';
+
+export default function MyComponent(props) {
+  function doSomethingAsync(event) {
+    void (async function() {
+      const response = await fetch();
+    })();
+  }
+
+  return <></>;
+}
+```
+
+### Callback implicitly have an "event" arg
+
+Regardless of what you make name the argument to a callback, it will be
+renamed in the output to `event`.
+
+_JSX Lite input_
+
+```typescript
+export default function MyComponent() {
+  return <input onClick={(e) => myCallback(e)} />;
+}
+```
+
+_JSX Lite output_
+
+```typescript
+export default function MyComponent(props) {
+  return (
+    <>
+      <input
+        onClick={(event) => {
+          myCallback(e);
+        }}
+      />
+    </>
+  );
+}
+```
+
+### Functions can't be passed by reference to JSX callbacks
+
+_JSX Lite input_
+
+```typescript
+export default function MyComponent() {
+  const state = useState({
+    myCallback(event) {
+      // do something
+    },
+  });
+
+  return <input onClick={state.myCallback} />;
+}
+```
+
+_JSX Lite output_
+
+```typescript
+import { useState } from 'react';
+
+export default function MyComponent(props) {
+  function myCallback(event) {
+    // do something
+  }
+
+  return (
+    <>
+      <input
+        onClick={(event) => {
+          myCallback;
+        }}
+      />
+    </>
+  );
+}
+```
+
+**Work around**
+
+Define an anonymous function in the callback
+
+_JSX Lite input_
+
+```typescript
+export default function MyComponent() {
+  const state = useState({
+    myCallback(event) {
+      // do something
+    },
+  });
+
+  return <input onClick={(event) => state.myCallback(event)} />;
+}
+```
+
+_JSX Lite output_
+
+```typescript
+import { useState } from 'react';
+
+export default function MyComponent(props) {
+  function myCallback(event) {
+    // do something
+  }
+
+  return (
+    <>
+      <input
+        onClick={(event) => {
+          myCallback(event);# JSX Lite Overview
+
+JSX Lite is a subset of [JSX](https://github.com/facebook/jsx). It supports generating code for a number of frontend frameworks, including React, Vue, Angular, Svelte, and Solid.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+**Table of contents**
+
+- [At a glance](#at-a-glance)
+- [Components](#components)
+- [Styling](#styling)
+- [State](#state)
+- [Methods](#methods)
+- [Control flow](#control-flow)
+  - [Show](#show)
+  - [For](#for)
+- [Refs](#refs)
+- [onMount](#onmount)
+- [onUnMount](#onunmount)
+- [Gotchas and limitations](#gotchas-and-limitations)
+  - [Defining variables with the same name as a state property will shadow it](#defining-variables-with-the-same-name-as-a-state-property-will-shadow-it)
+  - [Async methods can't be defined on "state"](#async-methods-cant-be-defined-on-state)
+  - [Callback implicitly have an "event" arg](#callback-implicitly-have-an-event-arg)
+  - [Functions can't be passed by reference to JSX callbacks](#functions-cant-be-passed-by-reference-to-jsx-callbacks)
+  - [Can't assign to "params" to "state"](#cant-assign-to-params-to-state)
+  - [Can't destructure assignment from state](#cant-destructure-assignment-from-state)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## At a glance
+
+JSX Lite is inspired by many modern frameworks. You'll see components look like React components and use React-like hooks, but have simple mutable state like Vue, use a static form of JSX like Solid, compile away like Svelte, and uses a simple, prescriptive structure like Angular.
+
+An example JSX Lite component showing several features:
+
+```javascript
+import { For, Show, useState } from '@jsx-lite/core';
+
+export default function MyComponent(props) {
+    return <></>;
 }
 ```


### PR DESCRIPTION
Adds a section for limitations and gotchas to the JSX Lite overview.

Will create another PR that will have some git hooks for formatting markdown on commit which I used for this later.