### PR TITLE
Add --prettier flag

### DIFF
--- a/packages/cli/src/commands/jsx-lite.ts
+++ b/packages/cli/src/commands/jsx-lite.ts
@@ -41,7 +41,7 @@ const command: GluegunCommand = {
     const header = opts.header
 
     const generatorOpts: { [K in AllGeneratorOptionKeys]: any } = {
-      prettier: true,
+      prettier: opts.prettier ?? true,
       plugins: [],
       format: opts.format,
       prefix: opts.prefix,


### PR DESCRIPTION
Adds an option to skip running output through prettier. I'm leaving this
undocumented as it's really only useful for debugging jsx-lite at the
moment.