### PR TITLE
Add "main" export

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@jsx-lite/core": "0.0.25",
+    "@jsx-lite/core": "0.0.27",
     "@types/fs-extra": "^9.0.8",
     "fs-extra": "^9.1.0",
     "globby": "^11.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,12 +22,13 @@
     "name": "Builder.io",
     "url": "https://www.builder.io"
   },
-  "exports": {
-    "./jsx": "./dist/src/jsx.js"
-  },
-  "version": "0.0.26",
+  "version": "0.0.27",
   "homepage": "https://github.com/BuilderIO/jsx-lite",
   "main": "./dist/src/index.js",
+  "exports": {
+    ".": "./dist/src/index.js",
+    "./jsx": "./dist/src/jsx.js"
+  },
   "types": "./dist/src/index.d.ts",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Exports needed this line

   ".": "./dist/src/index.js"

I tested the fix with

```bash
lerna link --force-local
cd packages/cli
npm run build && ./bin/jsx-lite compile --to react - < ../core/src/__tests__/data/basic.raw.tsx
```

Fixes https://github.com/BuilderIO/jsx-lite/issues/77