### PR TITLE
Add first pass at `jsx-lite new` sub command

### DIFF
--- a/packages/cli/scripts/test-new.sh
+++ b/packages/cli/scripts/test-new.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")" && pwd)"
+
+# At the package dir
+cd ../
+
+PATH="$(pwd)/bin:$PATH"
+
+tempdir=$(mktemp -d)
+
+cd "$tempdir"
+
+set -x
+
+jsx-lite new
+
+echo "exit-code: $?"
+
+ls -la

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -104,17 +104,7 @@ async function run(argv: any) {
     .version() // provides default for version, v, --version, -v
     // enable the following method if you'd like to skip loading one of these core extensions
     // this can improve performance if they're not necessary for your project:
-    .exclude([
-      // 'meta',
-      // 'print',
-      // 'filesystem',
-      // 'semver',
-      // 'system',
-      'http',
-      'template',
-      'patching',
-      'package-manager'
-    ])
+    .exclude([])
     .create()
   // and run it
   const toolbox = await cli.run(argv)

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -3,9 +3,67 @@ import { GluegunCommand } from 'gluegun'
 const command: GluegunCommand = {
   name: 'new',
   alias: 'n',
-  run: async toolbox => {
-    // TODO
+  description: 'jsx-lite new [options]',
+  async run(toolbox) {
+    const sys = toolbox.system
+    const pkg = toolbox.packageManager
+    const print = toolbox.print
+
+    async function exec(cmd, opts?) {
+      try {
+        const result = await sys.exec(cmd, opts)
+        result.stdout && print.info(result.stdout)
+      } catch (e) {
+        print.error(`Command failed with exit code ${e.exitCode}: ${e.command}`)
+        e.stdout && print.error(e.stdout)
+        e.stderr && print.error(e.stderr)
+        process.exit(1)
+      }
+    }
+
+    // npm init
+    const spinner = print.spin({})
+
+    spinner.start('Creating new project')
+
+    await exec('npm init -y')
+
+    spinner.succeed('Wrote package.json')
+
+    spinner.start('Installing packages')
+
+    await pkg.add(['@jsx-lite/core', '@jsx-lite/cli', 'typescript'], {
+      dev: true,
+      force: 'npm'
+    })
+
+    spinner.succeed('Installed packages')
+
+    toolbox.template.generate({
+      template: 'tsconfig.json.ejs',
+      target: 'tsconfig.json'
+    })
+
+    spinner.succeed('Wrote tsconfig.json')
+
+    toolbox.template.generate({
+      template: 'jsx-lite.config.js.ejs',
+      target: 'jsx-lite.config.js'
+    })
+
+    spinner.succeed('Wrote jsx-lite.config.js ')
+
+    toolbox.template.generate({
+      template: 'component.lite.tsx.ejs',
+      target: 'src/component.lite.tsx'
+    })
+
+    spinner.succeed('Wrote src/component.lite.tsx')
+
+    spinner.stopAndPersist({ text: 'Done!' })
+
+    return
   }
 }
 
-module.exports = command
+export default command

--- a/packages/cli/src/templates/component.lite.tsx.ejs
+++ b/packages/cli/src/templates/component.lite.tsx.ejs
@@ -1,0 +1,25 @@
+import '@jsx-lite/core/dist/jsx'
+import { useState, Show } from '@jsx-lite/core';
+
+interface Props {
+  showInput?: boolean
+}
+
+export default function MyComponent(props: Props) {
+  const state = useState({
+    name: 'Steve'
+  });
+
+  return (
+    <div>
+      <Show when={props.showInput}>
+        <input
+          css={{ color: 'red' }}
+          value={state.name}
+          onChange={(event) => (state.name = event.target.value)}
+        />
+      </Show>
+      Hello {state.name}! I can run in React, Vue, Solid, or Liquid!
+    </div>
+  );
+}

--- a/packages/cli/src/templates/jsx-lite.config.js.ejs
+++ b/packages/cli/src/templates/jsx-lite.config.js.ejs
@@ -1,0 +1,13 @@
+module.exports = {
+  files: 'src/**',
+  targets: [
+    'react',
+    'vue',
+    'html',
+    'svelte',
+    'solid',
+    'angular',
+    'builder',
+    'webcomponents'
+  ]
+}

--- a/packages/cli/src/templates/tsconfig.json.ejs
+++ b/packages/cli/src/templates/tsconfig.json.ejs
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "preserve"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds a rough first pass at a `new` sub command to generate a jsx-lite
project.

Adds package.json, jsx-lite dependencies, tsconfig, jsx-lite.config.js.

![image](https://user-images.githubusercontent.com/3162299/112878561-18c52700-9096-11eb-9172-595de9b5f455.png)

