### PR TITLE
Remove builder components on compile

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsx-lite/cli",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsx-lite/cli",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "description": "jsx-lite CLI",
   "types": "build/types/types.d.ts",
   "bin": {

--- a/packages/cli/src/__tests__/cli-integration.test.ts
+++ b/packages/cli/src/__tests__/cli-integration.test.ts
@@ -1,11 +1,15 @@
 import { filesystem, system } from 'gluegun'
 
-const { version } = require('../package.json')
+const { version } = require('../../package.json')
 
-const root = filesystem.path(__dirname, '..')
+const root = filesystem.path(__dirname, '..', '..')
 const script = filesystem.path(root, 'bin', 'jsx-lite')
 
-const cli = async (cmd: string) => system.run(`node ${script} ${cmd}`)
+const cli = async (cmd: string) => {
+  const shcmd = `node ${script} ${cmd}`
+  console.debug(`Running: ${shcmd}`)
+  return system.run(shcmd)
+}
 
 test('outputs version', async () => {
   const output = await cli('--version')

--- a/packages/cli/src/__tests__/cli-integration.test.ts
+++ b/packages/cli/src/__tests__/cli-integration.test.ts
@@ -38,7 +38,9 @@ test('strips out builder components by default', async () => {
 test('--builder-components keeps builder components', async () => {
   const filepath = require.resolve('./data/triptych.builder.json')
 
-  const output = await cli(`compile --builder-components --from=builder --to=react ${filepath}`)
+  const output = await cli(
+    `compile --builder-components --from=builder --to=react ${filepath}`
+  )
 
   expect(output).toContain('export default function MyComponent(props) {')
   expect(output).toContain('<Columns')

--- a/packages/cli/src/__tests__/cli-integration.test.ts
+++ b/packages/cli/src/__tests__/cli-integration.test.ts
@@ -20,3 +20,29 @@ test('outputs help', async () => {
   const output = await cli('--help')
   expect(output).toContain(version)
 })
+
+// TODO refactor commands/compile.ts to not have side effects (like calling
+// process.exit) so that this can be unit tested instead.
+test('strips out builder components by default', async () => {
+  const filepath = require.resolve('./data/triptych.builder.json')
+
+  const output = await cli(`compile --from=builder --to=react ${filepath}`)
+
+  expect(output).toContain('export default function MyComponent(props) {')
+  expect(output).not.toContain('<Columns')
+  expect(output).not.toContain('<Column')
+  expect(output).not.toContain('<Image')
+  expect(output).toContain('<img')
+})
+
+test('--builder-components keeps builder components', async () => {
+  const filepath = require.resolve('./data/triptych.builder.json')
+
+  const output = await cli(`compile --builder-components --from=builder --to=react ${filepath}`)
+
+  expect(output).toContain('export default function MyComponent(props) {')
+  expect(output).toContain('<Columns')
+  expect(output).toContain('<Column')
+  expect(output).toContain('<Image')
+  expect(output).not.toContain('<img')
+})

--- a/packages/cli/src/__tests__/data/triptych.builder.json
+++ b/packages/cli/src/__tests__/data/triptych.builder.json
@@ -1,0 +1,439 @@
+{
+  "data": {
+    "title": "Triptych three column layout template",
+    "hidden": "hello",
+    "blocks": [
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        "id": "builder-c205527e6ea84f648137eda08d445917",
+        "groupLocked": true,
+        "component": {
+          "name": "Columns",
+          "options": {
+            "columns": [
+              {
+                "blocks": [
+                  {
+                    "@type": "@builder.io/sdk:Element",
+                    "@version": 2,
+                    "id": "builder-7a687b4e9e71437d97f4f4567b5a405f",
+                    "component": {
+                      "name": "Image",
+                      "options": {
+                        "image": "https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=998&height=1000",
+                        "backgroundPosition": "center",
+                        "backgroundSize": "cover",
+                        "aspectRatio": 0.7004048582995948,
+                        "lazy": true,
+                        "srcset": "https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F8e096f01b00343dca3952d645f7ae024?width=376&height=1000 376w",
+                        "sizes": "(max-width: 638px) 100vw, 27vw",
+                        "height": 749,
+                        "width": 998
+                      }
+                    },
+                    "responsiveStyles": {
+                      "large": {
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "alignItems": "stretch",
+                        "flexShrink": "0",
+                        "position": "relative",
+                        "textAlign": "center",
+                        "lineHeight": "normal",
+                        "height": "auto"
+                      }
+                    }
+                  },
+                  {
+                    "@type": "@builder.io/sdk:Element",
+                    "@version": 2,
+                    "layerName": "Centered Box",
+                    "id": "builder-a657a370dd6b4975835f19fe81db9028",
+                    "children": [
+                      {
+                        "@type": "@builder.io/sdk:Element",
+                        "@version": 2,
+                        "layerName": "Title",
+                        "id": "builder-e0369e6217b94644b2ca95c5e7f9df9e",
+                        "component": {
+                          "name": "Text",
+                          "options": {
+                            "text": "<p>Something Great to Say</p>"
+                          }
+                        },
+                        "responsiveStyles": {
+                          "large": {
+                            "display": "flex",
+                            "flexDirection": "column",
+                            "alignItems": "stretch",
+                            "flexShrink": "0",
+                            "position": "relative",
+                            "marginTop": "-1.65625px",
+                            "textAlign": "center",
+                            "lineHeight": "normal",
+                            "height": "auto",
+                            "fontSize": "24px"
+                          },
+                          "medium": {
+                            "marginTop": "1.34375px",
+                            "textAlign": "center"
+                          },
+                          "small": {
+                            "fontSize": "25px"
+                          }
+                        }
+                      },
+                      {
+                        "@type": "@builder.io/sdk:Element",
+                        "@version": 2,
+                        "layerName": "Subtitle",
+                        "id": "builder-33f700bc894a4975bb34606268ec0b7f",
+                        "component": {
+                          "name": "Text",
+                          "options": {
+                            "text": "<p>Some more great things to elaborate on that wonderful things you have to tell your audience</p>"
+                          }
+                        },
+                        "responsiveStyles": {
+                          "large": {
+                            "display": "flex",
+                            "flexDirection": "column",
+                            "alignItems": "stretch",
+                            "flexShrink": "0",
+                            "position": "relative",
+                            "marginTop": "14.59375px",
+                            "textAlign": "center",
+                            "lineHeight": "normal",
+                            "height": "auto",
+                            "fontSize": "15px",
+                            "color": "rgba(86, 86, 86, 1)"
+                          },
+                          "medium": {
+                            "textAlign": "center"
+                          },
+                          "small": {
+                            "fontSize": "15px"
+                          }
+                        }
+                      }
+                    ],
+                    "responsiveStyles": {
+                      "large": {
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "alignItems": "stretch",
+                        "position": "relative",
+                        "flexShrink": "0",
+                        "boxSizing": "border-box",
+                        "marginTop": "9px",
+                        "marginBottom": "auto",
+                        "paddingBottom": "17px",
+                        "paddingTop": "17px"
+                      },
+                      "medium": {
+                        "paddingBottom": "49px"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "blocks": [
+                  {
+                    "@type": "@builder.io/sdk:Element",
+                    "@version": 2,
+                    "id": "builder-306706b011774f2ea07bb4d8ea26bd47",
+                    "component": {
+                      "name": "Image",
+                      "options": {
+                        "image": "https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=998&height=1000",
+                        "backgroundPosition": "center",
+                        "backgroundSize": "cover",
+                        "aspectRatio": 0.7004048582995948,
+                        "lazy": true,
+                        "srcset": "https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F70c33c597e9946e9a79ab99ad9a999d3?width=376&height=1000 376w",
+                        "sizes": "(max-width: 638px) 100vw, 27vw",
+                        "height": 665,
+                        "width": 998
+                      }
+                    },
+                    "responsiveStyles": {
+                      "large": {
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "alignItems": "stretch",
+                        "flexShrink": "0",
+                        "position": "relative",
+                        "textAlign": "center",
+                        "lineHeight": "normal",
+                        "height": "auto"
+                      },
+                      "medium": {
+                        "contentVisibility": "auto",
+                        "containIntrinsicSize": "699px"
+                      }
+                    }
+                  },
+                  {
+                    "@type": "@builder.io/sdk:Element",
+                    "@version": 2,
+                    "layerName": "Centered Box",
+                    "id": "builder-0dfa11ddca824dc38f1cdafe10dbbf7b",
+                    "children": [
+                      {
+                        "@type": "@builder.io/sdk:Element",
+                        "@version": 2,
+                        "layerName": "Title",
+                        "id": "builder-399e99cdaf164ec989e69f78f405e48f",
+                        "component": {
+                          "name": "Text",
+                          "options": {
+                            "text": "<p>Something Great to Say</p>"
+                          }
+                        },
+                        "responsiveStyles": {
+                          "large": {
+                            "display": "flex",
+                            "flexDirection": "column",
+                            "alignItems": "stretch",
+                            "flexShrink": "0",
+                            "position": "relative",
+                            "marginTop": "-1.65625px",
+                            "textAlign": "center",
+                            "lineHeight": "normal",
+                            "height": "auto",
+                            "fontSize": "24px"
+                          },
+                          "medium": {
+                            "marginTop": "1.34375px",
+                            "textAlign": "center"
+                          },
+                          "small": {
+                            "fontSize": "25px"
+                          }
+                        }
+                      },
+                      {
+                        "@type": "@builder.io/sdk:Element",
+                        "@version": 2,
+                        "layerName": "Subtitle",
+                        "id": "builder-7e06f73598864f728c37a63526fc993b",
+                        "component": {
+                          "name": "Text",
+                          "options": {
+                            "text": "<p>Some more great things to elaborate on that wonderful things you have to tell your audience</p>"
+                          }
+                        },
+                        "responsiveStyles": {
+                          "large": {
+                            "display": "flex",
+                            "flexDirection": "column",
+                            "alignItems": "stretch",
+                            "flexShrink": "0",
+                            "position": "relative",
+                            "marginTop": "14.59375px",
+                            "textAlign": "center",
+                            "lineHeight": "normal",
+                            "height": "auto",
+                            "fontSize": "15px",
+                            "color": "rgba(86, 86, 86, 1)"
+                          },
+                          "medium": {
+                            "textAlign": "center"
+                          },
+                          "small": {
+                            "fontSize": "15px"
+                          }
+                        }
+                      }
+                    ],
+                    "responsiveStyles": {
+                      "large": {
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "alignItems": "stretch",
+                        "position": "relative",
+                        "flexShrink": "0",
+                        "boxSizing": "border-box",
+                        "marginTop": "9px",
+                        "marginBottom": "auto",
+                        "paddingBottom": "17px",
+                        "paddingTop": "17px"
+                      },
+                      "medium": {
+                        "paddingBottom": "49px",
+                        "contentVisibility": "auto",
+                        "containIntrinsicSize": "92px"
+                      },
+                      "small": {
+                        "contentVisibility": "auto",
+                        "containIntrinsicSize": "128px"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "blocks": [
+                  {
+                    "@type": "@builder.io/sdk:Element",
+                    "@version": 2,
+                    "id": "builder-9ef154861ab5443d96aedce939ddf521",
+                    "component": {
+                      "name": "Image",
+                      "options": {
+                        "image": "https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=998&height=1000",
+                        "backgroundPosition": "center",
+                        "backgroundSize": "cover",
+                        "aspectRatio": 0.7004048582995948,
+                        "lazy": true,
+                        "srcset": "https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=100&height=1000 100w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=200&height=1000 200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=400&height=1000 400w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=800&height=1000 800w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=1200&height=1000 1200w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=1600&height=1000 1600w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=2000&height=1000 2000w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=998&height=1000 998w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=638&height=1000 638w, https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2F226d855cb0ee46e4a2c7baa6990c1118?width=376&height=1000 376w",
+                        "sizes": "(max-width: 638px) 100vw, 27vw",
+                        "height": 685,
+                        "width": 998
+                      }
+                    },
+                    "responsiveStyles": {
+                      "large": {
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "alignItems": "stretch",
+                        "flexShrink": "0",
+                        "position": "relative",
+                        "textAlign": "center",
+                        "lineHeight": "normal",
+                        "height": "auto"
+                      },
+                      "medium": {
+                        "contentVisibility": "auto",
+                        "containIntrinsicSize": "699px"
+                      },
+                      "small": {
+                        "contentVisibility": "auto",
+                        "containIntrinsicSize": "447px"
+                      }
+                    }
+                  },
+                  {
+                    "@type": "@builder.io/sdk:Element",
+                    "@version": 2,
+                    "layerName": "Centered Box",
+                    "id": "builder-31a8fe351a2f4ac0abff9dea2b0a9d65",
+                    "children": [
+                      {
+                        "@type": "@builder.io/sdk:Element",
+                        "@version": 2,
+                        "layerName": "Title",
+                        "id": "builder-cd3a8932d54549979d32352c4d6d5809",
+                        "component": {
+                          "name": "Text",
+                          "options": {
+                            "text": "<p>Something Great to Say</p>"
+                          }
+                        },
+                        "responsiveStyles": {
+                          "large": {
+                            "display": "flex",
+                            "flexDirection": "column",
+                            "alignItems": "stretch",
+                            "flexShrink": "0",
+                            "position": "relative",
+                            "marginTop": "-1.65625px",
+                            "textAlign": "center",
+                            "lineHeight": "normal",
+                            "height": "auto",
+                            "fontSize": "24px"
+                          },
+                          "medium": {
+                            "marginTop": "1.34375px",
+                            "textAlign": "center"
+                          },
+                          "small": {
+                            "fontSize": "25px"
+                          }
+                        }
+                      },
+                      {
+                        "@type": "@builder.io/sdk:Element",
+                        "@version": 2,
+                        "layerName": "Subtitle",
+                        "id": "builder-634fcbb6974e4897b6b387f80974dc55",
+                        "component": {
+                          "name": "Text",
+                          "options": {
+                            "text": "<p>Some more great things to elaborate on that wonderful things you have to tell your audience</p>"
+                          }
+                        },
+                        "responsiveStyles": {
+                          "large": {
+                            "display": "flex",
+                            "flexDirection": "column",
+                            "alignItems": "stretch",
+                            "flexShrink": "0",
+                            "position": "relative",
+                            "marginTop": "14.59375px",
+                            "textAlign": "center",
+                            "lineHeight": "normal",
+                            "height": "auto",
+                            "fontSize": "15px",
+                            "color": "rgba(86, 86, 86, 1)"
+                          },
+                          "medium": {
+                            "textAlign": "center"
+                          },
+                          "small": {
+                            "fontSize": "15px"
+                          }
+                        }
+                      }
+                    ],
+                    "responsiveStyles": {
+                      "large": {
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "alignItems": "stretch",
+                        "position": "relative",
+                        "flexShrink": "0",
+                        "boxSizing": "border-box",
+                        "marginTop": "9px",
+                        "marginBottom": "auto",
+                        "paddingBottom": "17px",
+                        "paddingTop": "17px"
+                      },
+                      "medium": {
+                        "paddingBottom": "49px",
+                        "contentVisibility": "auto",
+                        "containIntrinsicSize": "92px"
+                      },
+                      "small": {
+                        "contentVisibility": "auto",
+                        "containIntrinsicSize": "128px"
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "space": 36,
+            "stackColumnsAt": "tablet",
+            "reverseColumnsWhenStacked": false
+          }
+        },
+        "responsiveStyles": {
+          "large": {
+            "display": "flex",
+            "flexDirection": "column",
+            "alignItems": "stretch",
+            "position": "relative",
+            "flexShrink": "0",
+            "boxSizing": "border-box",
+            "marginTop": "2.34375px",
+            "paddingLeft": "0px",
+            "paddingRight": "0px"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -81,6 +81,10 @@ OUTPUT OPTIONS
 		Add a preamble to the document. Useful if you want to include a
 		license or an import statement. Header will be ignored if the
 		output is JSON.
+	--builder-components
+		Compiled output should will include builder components where
+		available. Useful if you're outputing jsx-lite that will run
+		in Builder.
 
 GENERATOR OPTIONS
 	--format=<format>

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1,4 +1,4 @@
-import { builderContentToJsxLiteComponent, parseJsx } from '@jsx-lite/core'
+import { builderContentToJsxLiteComponent, JSXLiteComponent, parseJsx } from '@jsx-lite/core'
 import { GluegunCommand } from 'gluegun'
 import { join } from 'path'
 import * as targets from '../targets'
@@ -98,7 +98,7 @@ const command: GluegunCommand = {
       }
 
       try {
-        let json
+        let json: JSXLiteComponent
 
         switch (from_) {
           case 'jsxLite':

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1,4 +1,9 @@
-import { builderContentToJsxLiteComponent, compileAwayBuilderComponents, JSXLiteComponent, parseJsx } from '@jsx-lite/core'
+import {
+  builderContentToJsxLiteComponent,
+  compileAwayBuilderComponents,
+  JSXLiteComponent,
+  parseJsx
+} from '@jsx-lite/core'
 import { GluegunCommand } from 'gluegun'
 import { join } from 'path'
 import * as targets from '../targets'
@@ -34,7 +39,7 @@ const command: GluegunCommand = {
 
     const header = opts.header
 
-    const plugins = [];
+    const plugins = []
 
     if (!opts.builderComponents) {
       plugins.push(compileAwayBuilderComponents())

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1,4 +1,4 @@
-import { builderContentToJsxLiteComponent, JSXLiteComponent, parseJsx } from '@jsx-lite/core'
+import { builderContentToJsxLiteComponent, compileAwayBuilderComponents, JSXLiteComponent, parseJsx } from '@jsx-lite/core'
 import { GluegunCommand } from 'gluegun'
 import { join } from 'path'
 import * as targets from '../targets'
@@ -34,9 +34,15 @@ const command: GluegunCommand = {
 
     const header = opts.header
 
+    const plugins = [];
+
+    if (!opts.builderComponents) {
+      plugins.push(compileAwayBuilderComponents())
+    }
+
     const generatorOpts: { [K in AllGeneratorOptionKeys]: any } = {
       prettier: opts.prettier ?? true,
-      plugins: [],
+      plugins: plugins,
       format: opts.format,
       prefix: opts.prefix,
       includeIds: opts.includeIds,

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -1,4 +1,5 @@
 import dedent from 'dedent';
+import * as fs from 'fs';
 import { componentToBuilder } from '../generators/builder';
 import { componentToJsxLite } from '../generators/jsx-lite';
 import {
@@ -7,11 +8,19 @@ import {
 } from '../parsers/builder';
 import { parseJsx } from '../parsers/jsx';
 
-const stamped = require('./data/blocks/stamped-io.raw');
-const customCode = require('./data/blocks/custom-code.raw');
-const embed = require('./data/blocks/embed.raw');
-const image = require('./data/blocks/image.raw');
-const columns = require('./data/blocks/columns.raw');
+/**
+ * Load a file using nodejs resolution as a string.
+ */
+function fixture(path: string): string {
+  const localpath = require.resolve(path);
+  return fs.readFileSync(localpath, { encoding: 'utf-8' });
+}
+
+const stamped = fixture('./data/blocks/stamped-io.raw');
+const customCode = fixture('./data/blocks/custom-code.raw');
+const embed = fixture('./data/blocks/embed.raw');
+const image = fixture('./data/blocks/image.raw');
+const columns = fixture('./data/blocks/columns.raw');
 
 describe('Builder', () => {
   test('extractStateHook', () => {
@@ -85,7 +94,7 @@ describe('Builder', () => {
 
       export default function MyComponent(props) {
         const state = useState({ people: ["Steve", "Sewell"] });
-      
+
         return (
           <div
             css={{
@@ -116,7 +125,7 @@ describe('Builder', () => {
 
       export default function MyComponent(props) {
         const state = useState({ people: ["Steve", "Sewell"] });
-      
+
         return (
           <div
             css={{
@@ -148,7 +157,7 @@ describe('Builder', () => {
 
       export default function MyComponent(props) {
         const state = useState({ people: ["Steve", "Sewell"] });
-      
+
         return (
           <For each={state.people}>
             {(person, index) => (
@@ -196,7 +205,7 @@ describe('Builder', () => {
             }}
           />
         );
-      }    
+      }
     `;
 
     const json = parseJsx(code);
@@ -222,7 +231,7 @@ describe('Builder', () => {
             </>
           </>
         );
-      }    
+      }
     `;
 
     const json = parseJsx(code);
@@ -255,7 +264,7 @@ describe('Builder', () => {
             </span>
           </div>
         );
-      }    
+      }
     `;
 
     const json = parseJsx(code);

--- a/packages/core/src/__tests__/builder.test.ts
+++ b/packages/core/src/__tests__/builder.test.ts
@@ -30,7 +30,6 @@ describe('Builder', () => {
       state: { foo: 'bar' },
     });
 
-    const code2 = `Object.assign(state, { foo: 'bar' }); alert('hi');`;
     expect(extractStateHook(code)).toEqual({
       code: `alert('hi');`,
       state: { foo: 'bar' },

--- a/packages/core/src/generators/qoot.ts
+++ b/packages/core/src/generators/qoot.ts
@@ -220,9 +220,9 @@ const blockToQoot = (json: JSXLiteNode, options: InternalToQootOptions) => {
       } else {
         eventBindings[useKey] = `QRL\`${
           options.qrlPrefix
-        }/${componentName}/on${elId(json, options)}${key.slice(2)}${
-          options.qrlSuffix || ''
-        }?event=.\``;
+        }/${componentName}/on${elId(json, options)}${key.slice(
+          2,
+        )}${options.qrlSuffix || ''}?event=.\``;
       }
     } else {
       if (!isValidAttributeName(key)) {
@@ -295,7 +295,7 @@ const getEventHandlerFiles = (
 ): File[] => {
   const files: File[] = [];
 
-  traverse(componentJson).forEach(function (item) {
+  traverse(componentJson).forEach(function(item) {
     if (isJsxLiteNode(item)) {
       for (const binding in item.bindings) {
         if (binding.startsWith('on')) {


### PR DESCRIPTION
## Description

Adds a new flag `--builder-components` that produces portable html output
in place of including react components that only exist within Builder.

BREAKING CHANGE: default output of the compile sub command has changed.
Output would previously always make use of builder custom components,
like `<Image />`, `<Columns />`, etc. Instead, standard html tags and
attributes are generated instead. This behaviour is now opt-in with
`--builder-components` flag.


## Changelog

- fix(cli): use a more specific type
- refactor(cli): don't use require to load string
- fix(cli): remove dead code
- chore: move integration test
- feat(cli): add --builder-components flag

## Related
- https://github.com/BuilderIO/jsx-lite/issues/88
