### PR TITLE
Don't crash when going handling empty Column blocks

### DIFF
--- a/packages/core/src/parsers/builder.ts
+++ b/packages/core/src/parsers/builder.ts
@@ -345,7 +345,7 @@ const componentMappers: {
     delete node.bindings.columns;
     delete node.properties.columns;
 
-    node.children = block.component?.options.columns.map(
+    node.children = block.component?.options.columns?.map(
       (col: any, index: number) =>
         createJSXLiteNode({
           name: 'Column',


### PR DESCRIPTION
Sometimes users just left empty Columns around; and while this is fine, this can make the Builder parser to crash because it assumes Columns always have columns...