### PR TITLE
Improvements for SolidJS output

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsx-lite/core",
-  "version": "0.0.44-10",
+  "version": "0.0.44-11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
     "name": "Builder.io",
     "url": "https://www.builder.io"
   },
-  "version": "0.0.44-10",
+  "version": "0.0.44-11",
   "homepage": "https://github.com/BuilderIO/jsx-lite",
   "main": "./dist/src/index.js",
   "exports": {

--- a/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
@@ -918,10 +918,8 @@ Object {
         },
       },
     ],
-    "jsCode": "Object.assign(state, {});
-",
-    "tsCode": "useState({});
-",
+    "jsCode": "",
+    "tsCode": "",
   },
 }
 `;

--- a/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/solid.test.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Solid Basic 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
+"import { createMutable } from \\"solid-js\\";
 
-export default function MyBasicComponent() {
+export default function MyBasicComponent(props) {
   const state = createMutable({ name: \\"Steve\\" });
 
   return (
@@ -20,11 +20,9 @@ export default function MyBasicComponent() {
 `;
 
 exports[`Solid Button 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
+"import { Show } from \\"solid-js\\";
 
-export default function Button() {
-  const state = createMutable({});
-
+export default function Button(props) {
   return (
     <Fragment>
       <Show when={props.link}>
@@ -49,10 +47,10 @@ export default function Button() {
 `;
 
 exports[`Solid Columns 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
+"import { createMutable, For } from \\"solid-js\\";
 import { css } from \\"solid-styled-components\\";
 
-export default function Column() {
+export default function Column(props) {
   const state = createMutable({
     // TODO: These methods are not used right now, but they will be when
     // support for dynamic CSS lands
@@ -100,9 +98,9 @@ export default function Column() {
 `;
 
 exports[`Solid CustomCode 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
+"import { createMutable } from \\"solid-js\\";
 
-export default function CustomCode() {
+export default function CustomCode(props) {
   const state = createMutable({
     scriptsInserted: [],
     scriptsRun: [],
@@ -165,9 +163,9 @@ export default function CustomCode() {
 `;
 
 exports[`Solid Embed 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
+"import { createMutable } from \\"solid-js\\";
 
-export default function CustomCode() {
+export default function CustomCode(props) {
   const state = createMutable({
     scriptsInserted: [],
     scriptsRun: [],
@@ -239,7 +237,7 @@ import { BuilderBlocks } from \\"@fake\\";
 import { set } from \\"@fake\\";
 import { get } from \\"@fake\\";
 
-export default function FormComponent() {
+export default function FormComponent(props) {
   const state = createMutable({
     state: \\"unsubmitted\\",
     responseData: null,
@@ -530,10 +528,10 @@ export default function FormComponent() {
 `;
 
 exports[`Solid Image 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
+"import { createMutable, Show } from \\"solid-js\\";
 import { css } from \\"solid-styled-components\\";
 
-export default function Image() {
+export default function Image(props) {
   const state = createMutable({
     scrollListener: null,
     imageLoaded: false,
@@ -591,13 +589,9 @@ export default function Image() {
 `;
 
 exports[`Solid Img 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
+"import { Builder } from \\"@builder.io/sdk\\";
 
-import { Builder } from \\"@builder.io/sdk\\";
-
-export default function ImgComponent() {
-  const state = createMutable({});
-
+export default function ImgComponent(props) {
   return (
     <img
       {...props.attributes}
@@ -615,13 +609,9 @@ export default function ImgComponent() {
 `;
 
 exports[`Solid Input block 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
+"import { Builder } from \\"@builder.io/sdk\\";
 
-import { Builder } from \\"@builder.io/sdk\\";
-
-export default function FormInputComponent() {
-  const state = createMutable({});
-
+export default function FormInputComponent(props) {
   return (
     <input
       {...props.attributes}
@@ -643,11 +633,7 @@ export default function FormInputComponent() {
 `;
 
 exports[`Solid RawText 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
-
-export default function RawText() {
-  const state = createMutable({});
-
+"export default function RawText(props) {
   return (
     <span
       class={props.attributes?.class || props.attributes?.className}
@@ -659,11 +645,7 @@ export default function RawText() {
 `;
 
 exports[`Solid Section 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
-
-export default function SectionComponent() {
-  const state = createMutable({});
-
+"export default function SectionComponent(props) {
   return (
     <section
       {...props.attributes}
@@ -683,13 +665,11 @@ export default function SectionComponent() {
 `;
 
 exports[`Solid Select block 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
+"import { For } from \\"solid-js\\";
 
 import { Builder } from \\"@builder.io/sdk\\";
 
-export default function SelectComponent() {
-  const state = createMutable({});
-
+export default function SelectComponent(props) {
   return (
     <select
       {...props.attributes}
@@ -712,11 +692,7 @@ export default function SelectComponent() {
 `;
 
 exports[`Solid Submit button block 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
-
-export default function SubmitButton() {
-  const state = createMutable({});
-
+"export default function SubmitButton(props) {
   return (
     <button {...props.attributes} type=\\"submit\\">
       {props.text}
@@ -727,13 +703,9 @@ export default function SubmitButton() {
 `;
 
 exports[`Solid Text 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
+"import { Builder } from \\"@builder.io/sdk\\";
 
-import { Builder } from \\"@builder.io/sdk\\";
-
-export default function Text() {
-  const state = createMutable({});
-
+export default function Text(props) {
   return (
     <div
       contentEditable={allowEditingText || undefined}
@@ -745,11 +717,7 @@ export default function Text() {
 `;
 
 exports[`Solid Textarea 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
-
-export default function Textarea() {
-  const state = createMutable({});
-
+"export default function Textarea(props) {
   return (
     <textarea
       {...props.attributes}
@@ -764,11 +732,7 @@ export default function Textarea() {
 `;
 
 exports[`Solid Video 1`] = `
-"import { createMutable, Show, For } from \\"solid-js\\";
-
-export default function Video() {
-  const state = createMutable({});
-
+"export default function Video(props) {
   return (
     <video
       {...props.attributes}

--- a/packages/core/src/generators/builder.ts
+++ b/packages/core/src/generators/builder.ts
@@ -128,7 +128,11 @@ const el = (
 ): BuilderElement => ({
   '@type': '@builder.io/sdk:Element',
   ...(toBuilderOptions.includeIds && {
-    id: 'builder-' + Math.random().toString(36).split('.')[1],
+    id:
+      'builder-' +
+      Math.random()
+        .toString(36)
+        .split('.')[1],
   }),
   ...options,
 });
@@ -196,8 +200,9 @@ export const blockToBuilder = (
 
   for (const key in bindings) {
     const eventBindingKeyRegex = /^on([A-Z])/;
-    const firstCharMatchForEventBindingKey =
-      key.match(eventBindingKeyRegex)?.[1];
+    const firstCharMatchForEventBindingKey = key.match(
+      eventBindingKeyRegex,
+    )?.[1];
     if (firstCharMatchForEventBindingKey) {
       actions[
         key.replace(

--- a/packages/core/src/generators/builder.ts
+++ b/packages/core/src/generators/builder.ts
@@ -128,11 +128,7 @@ const el = (
 ): BuilderElement => ({
   '@type': '@builder.io/sdk:Element',
   ...(toBuilderOptions.includeIds && {
-    id:
-      'builder-' +
-      Math.random()
-        .toString(36)
-        .split('.')[1],
+    id: 'builder-' + Math.random().toString(36).split('.')[1],
   }),
   ...options,
 });
@@ -200,9 +196,8 @@ export const blockToBuilder = (
 
   for (const key in bindings) {
     const eventBindingKeyRegex = /^on([A-Z])/;
-    const firstCharMatchForEventBindingKey = key.match(
-      eventBindingKeyRegex,
-    )?.[1];
+    const firstCharMatchForEventBindingKey =
+      key.match(eventBindingKeyRegex)?.[1];
     if (firstCharMatchForEventBindingKey) {
       actions[
         key.replace(
@@ -311,7 +306,7 @@ export const componentToBuilder = (
   componentJson: JSXLiteComponent,
   options: ToBuilderOptions = {},
 ) => {
-  const hasState = Boolean(Object.keys(componentJson).length);
+  const hasState = Boolean(Object.keys(componentJson.state).length);
 
   return fastClone({
     data: {

--- a/packages/core/src/helpers/get-components-used.ts
+++ b/packages/core/src/helpers/get-components-used.ts
@@ -1,0 +1,15 @@
+import { JSXLiteComponent } from 'src/types/jsx-lite-component';
+import traverse from 'traverse';
+import { isJsxLiteNode } from './is-jsx-lite-node';
+
+export function getComponentsUsed(json: JSXLiteComponent) {
+  const components = new Set<string>();
+
+  traverse(json).forEach(function(item) {
+    if (isJsxLiteNode(item)) {
+      components.add(item.name);
+    }
+  });
+
+  return components;
+}

--- a/packages/core/src/helpers/get-components-used.ts
+++ b/packages/core/src/helpers/get-components-used.ts
@@ -1,4 +1,4 @@
-import { JSXLiteComponent } from 'src/types/jsx-lite-component';
+import { JSXLiteComponent } from '../types/jsx-lite-component';
 import traverse from 'traverse';
 import { isJsxLiteNode } from './is-jsx-lite-node';
 


### PR DESCRIPTION
- include props in output
- don't add empty `css` attribute
- only include needed imports
- don't include createMutable if not needed

also:
- removes `debugger` from Fiddle
- disables buggy focus syncing for now from Fiddle

Fixes #98 

<img width="1459" alt="Screen Shot 2021-06-18 at 11 28 06 AM" src="https://user-images.githubusercontent.com/844291/122602792-42a04100-d028-11eb-91fa-535436f75f73.png">
