### PR TITLE
fix: ignore invalid attributes when generating JSX output

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/builder.test.ts.snap
@@ -1748,7 +1748,6 @@ export default function MyComponent(props) {
       <For each={state.reviews}>
         {(review, index) => (
           <div
-            $name=\\"Review\\"
             css={{
               margin: \\"10px\\",
               padding: \\"10px\\",

--- a/packages/core/src/generators/jsx-lite.ts
+++ b/packages/core/src/generators/jsx-lite.ts
@@ -50,7 +50,11 @@ export const blockToJsxLite = (
       .replace(/"/g, '&quot;')
       .replace(/\n/g, '\\n');
 
-    str += ` ${key}="${value}" `;
+    if (!isValidAttributeName(key)) {
+      console.warn('Skipping invalid attribute name:', key);
+    } else {
+      str += ` ${key}="${value}" `;
+    }
   }
   for (const key in json.bindings) {
     const value = json.bindings[key] as string;


### PR DESCRIPTION
Attributes which have no key are not valid. They should never be part of
the input, but if they are the best is to just ignore them.