### PR TITLE
fix: import `StyleSheet` from react native

### DIFF
--- a/.changeset/big-bears-eat.md
+++ b/.changeset/big-bears-eat.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+[React Native] Fix: import `StyleSheet` from React Native when styles are used

--- a/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/react-native.test.ts.snap
@@ -4064,7 +4064,7 @@ export default TypeGetterStore;
 
 exports[`React Native > jsx > Javascript Test > use-style 1`] = `
 "import * as React from \\"react\\";
-import { View, StyleSheet, Text, Button } from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props) {
   return (
@@ -4073,8 +4073,6 @@ function MyComponent(props) {
     </Button>
   );
 }
-
-const styles = StyleSheet.create({});
 
 export default MyComponent;
 "
@@ -4102,7 +4100,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Javascript Test > use-style-outside-component 1`] = `
 "import * as React from \\"react\\";
-import { View, StyleSheet, Text, Button } from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props) {
   return (
@@ -4111,8 +4109,6 @@ function MyComponent(props) {
     </Button>
   );
 }
-
-const styles = StyleSheet.create({});
 
 export default MyComponent;
 "
@@ -8669,7 +8665,7 @@ export default TypeGetterStore;
 
 exports[`React Native > jsx > Typescript Test > use-style 1`] = `
 "import * as React from \\"react\\";
-import { View, StyleSheet, Text, Button } from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return (
@@ -8678,8 +8674,6 @@ function MyComponent(props: any) {
     </Button>
   );
 }
-
-const styles = StyleSheet.create({});
 
 export default MyComponent;
 "
@@ -8707,7 +8701,7 @@ export default MyComponent;
 
 exports[`React Native > jsx > Typescript Test > use-style-outside-component 1`] = `
 "import * as React from \\"react\\";
-import { View, StyleSheet, Text, Button } from \\"react-native\\";
+import { View, Text, Button } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return (
@@ -8716,8 +8710,6 @@ function MyComponent(props: any) {
     </Button>
   );
 }
-
-const styles = StyleSheet.create({});
 
 export default MyComponent;
 "
@@ -9178,13 +9170,11 @@ export default MyComponent;
 
 exports[`React Native > svelte > Javascript Test > style 1`] = `
 "import * as React from \\"react\\";
-import { StyleSheet, TextInput } from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyComponent(props) {
   return <TextInput />;
 }
-
-const styles = StyleSheet.create({});
 
 export default MyComponent;
 "
@@ -9589,13 +9579,11 @@ export default MyComponent;
 
 exports[`React Native > svelte > Typescript Test > style 1`] = `
 "import * as React from \\"react\\";
-import { StyleSheet, TextInput } from \\"react-native\\";
+import { TextInput } from \\"react-native\\";
 
 function MyComponent(props: any) {
   return <TextInput />;
 }
-
-const styles = StyleSheet.create({});
 
 export default MyComponent;
 "

--- a/packages/core/src/generators/react/generator.ts
+++ b/packages/core/src/generators/react/generator.ts
@@ -489,7 +489,7 @@ const _componentToReact = (
   }${isForwardRef ? ')' : ''}
 
     ${
-      reactNativeStyles
+      reactNativeStyles && Object.keys(reactNativeStyles).length > 0
         ? `const styles = StyleSheet.create(${json5.stringify(reactNativeStyles)});`
         : ''
     }

--- a/packages/core/src/generators/react/helpers/state.ts
+++ b/packages/core/src/generators/react/helpers/state.ts
@@ -4,7 +4,6 @@ import { getStateObjectStringFromComponent } from '@/helpers/get-state-object-st
 import { getTypedFunction } from '@/helpers/get-typed-function';
 import { isMitosisNode } from '@/helpers/is-mitosis-node';
 import { prefixWithFunction, replaceGetterWithFunction } from '@/helpers/patterns';
-import { hasCss } from '@/helpers/styles/helpers';
 import { transformStateSetters } from '@/helpers/transform-state-setters';
 import { MitosisComponent, StateValue } from '@/types/mitosis-component';
 import { types } from '@babel/core';
@@ -172,10 +171,6 @@ export const getDefaultImport = (options: ToReactOptions, json: MitosisComponent
         });
       }
     });
-
-    if (hasCss(json)) {
-      namesUsed.add('StyleSheet');
-    }
 
     traverse(json).forEach((node) => {
       if (!isMitosisNode(node)) {


### PR DESCRIPTION
## Description

whenever `collectReactNativeStyles` runs (early)
https://github.com/BuilderIO/mitosis/blob/8d68cc5f4e8ebb57cb79b07135e7914862a82e69/packages/core/src/generators/react-native/index.ts#L51
it deletes all the css bindings so hasCss always returns `false` (ref PR https://github.com/BuilderIO/mitosis/pull/1761). This checks if a node has style property/binding and adds `StyleSheet` to the imports

https://builder-io.atlassian.net/browse/ENG-9486

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
