### PR TITLE
fix: nested slots inside Mitosis components

### DIFF
--- a/.changeset/fair-ways-carry.md
+++ b/.changeset/fair-ways-carry.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+fix: nested slots inside Mitosis components for angular, stencil and vue

--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -2554,7 +2554,11 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
   styles: [
@@ -10843,7 +10847,11 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
   styles: [

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -2588,7 +2588,11 @@ import ContentSlotCodeModule from \\"./content-slot-jsx.raw/angular\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
   styles: [
@@ -11017,7 +11021,11 @@ import ContentSlotCodeModule from \\"./content-slot-jsx.raw/angular\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
   styles: [

--- a/packages/core/src/__tests__/__snapshots__/angular.signals.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.signals.test.ts.snap
@@ -2219,7 +2219,11 @@ import { ContentSlotCode } from \\"./content-slot-jsx.raw\\";
   standalone: true,
   imports: [CommonModule, ContentSlotCode],
   template: \`<div>
-    <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+    <content-slot-code>
+      <ng-container slot-testing>
+        <div>Hello</div>
+      </ng-container>
+    </content-slot-code>
   </div> \`,
   styles: \`:host { display: contents; }\`,
 })
@@ -9260,7 +9264,11 @@ import { ContentSlotCode } from \\"./content-slot-jsx.raw\\";
   standalone: true,
   imports: [CommonModule, ContentSlotCode],
   template: \`<div>
-    <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+    <content-slot-code>
+      <ng-container slot-testing>
+        <div>Hello</div>
+      </ng-container>
+    </content-slot-code>
   </div> \`,
   styles: \`:host { display: contents; }\`,
 })

--- a/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
@@ -2647,7 +2647,11 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
   styles: [
@@ -11261,7 +11265,11 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
   styles: [

--- a/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
@@ -2340,7 +2340,11 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
 })
@@ -9733,7 +9737,11 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
 })

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -4889,7 +4889,11 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
   styles: [
@@ -4922,7 +4926,11 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
   styles: [
@@ -20591,7 +20599,11 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
   styles: [
@@ -20628,7 +20640,11 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
   selector: \\"slot-code\\",
   template: \`
     <div>
-      <content-slot-code [slotTesting]=\\"<div>Hello</div>\\"></content-slot-code>
+      <content-slot-code>
+        <ng-container slot-testing>
+          <div>Hello</div>
+        </ng-container>
+      </content-slot-code>
     </div>
   \`,
   styles: [

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -1719,7 +1719,9 @@ export class SlotCode {
     return (
       <div>
         <content-slot-code>
-          <slot testing={<div>Hello</div>}></slot>
+          <slot>
+            <div slot=\\"testing\\">Hello</div>
+          </slot>
         </content-slot-code>
       </div>
     );
@@ -1742,7 +1744,9 @@ export class SlotCode {
   render() {
     return (
       <div>
-        <content-slot-code slotTesting={<div>Hello</div>}></content-slot-code>
+        <content-slot-code>
+          <div slot=\\"slotTesting\\">Hello</div>
+        </content-slot-code>
       </div>
     );
   }
@@ -6341,7 +6345,9 @@ export class SlotCode {
     return (
       <div>
         <content-slot-code>
-          <slot testing={<div>Hello</div>}></slot>
+          <slot>
+            <div slot=\\"testing\\">Hello</div>
+          </slot>
         </content-slot-code>
       </div>
     );
@@ -6364,7 +6370,9 @@ export class SlotCode {
   render() {
     return (
       <div>
-        <content-slot-code slotTesting={<div>Hello</div>}></content-slot-code>
+        <content-slot-code>
+          <div slot=\\"slotTesting\\">Hello</div>
+        </content-slot-code>
       </div>
     );
   }

--- a/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue-composition.test.ts.snap
@@ -1362,7 +1362,13 @@ import ContentSlotCode from \\"./content-slot-jsx.raw\\";
 
 exports[`Vue > jsx > Javascript Test > SlotJsx 1`] = `
 "<template>
-  <div><ContentSlotCode :slotTesting=\\"<div>Hello</div>\\"></ContentSlotCode></div>
+  <div>
+    <ContentSlotCode>
+      <template #slot-testing>
+        <div>Hello</div>
+      </template>
+    </ContentSlotCode>
+  </div>
 </template>
 
 <script setup>
@@ -5104,7 +5110,13 @@ type Props = {
 
 exports[`Vue > jsx > Typescript Test > SlotJsx 1`] = `
 "<template>
-  <div><ContentSlotCode :slotTesting=\\"<div>Hello</div>\\"></ContentSlotCode></div>
+  <div>
+    <ContentSlotCode>
+      <template #slot-testing>
+        <div>Hello</div>
+      </template>
+    </ContentSlotCode>
+  </div>
 </template>
 
 <script setup lang=\\"ts\\">

--- a/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/vue.test.ts.snap
@@ -1601,7 +1601,13 @@ export default defineComponent({
 
 exports[`Vue > jsx > Javascript Test > SlotJsx 1`] = `
 "<template>
-  <div><ContentSlotCode :slotTesting=\\"<div>Hello</div>\\"></ContentSlotCode></div>
+  <div>
+    <ContentSlotCode>
+      <template #slot-testing>
+        <div>Hello</div>
+      </template>
+    </ContentSlotCode>
+  </div>
 </template>
 
 <script>
@@ -6293,7 +6299,13 @@ export default defineComponent({
 
 exports[`Vue > jsx > Typescript Test > SlotJsx 1`] = `
 "<template>
-  <div><ContentSlotCode :slotTesting=\\"<div>Hello</div>\\"></ContentSlotCode></div>
+  <div>
+    <ContentSlotCode>
+      <template #slot-testing>
+        <div>Hello</div>
+      </template>
+    </ContentSlotCode>
+  </div>
 </template>
 
 <script lang=\\"ts\\">

--- a/packages/core/src/generators/angular/classic/blocks.ts
+++ b/packages/core/src/generators/angular/classic/blocks.ts
@@ -9,6 +9,7 @@ import {
 import { parseSelector } from '@/generators/angular/helpers/parse-selector';
 import { AngularBlockOptions, ToAngularOptions } from '@/generators/angular/types';
 import { createSingleBinding } from '@/helpers/bindings';
+import { dashCase } from '@/helpers/dash-case';
 import { checkIsBindingNativeEvent, checkIsEvent } from '@/helpers/event-handlers';
 import { getBuilderTagName } from '@/helpers/get-tag-name';
 import isChildren from '@/helpers/is-children';
@@ -468,6 +469,9 @@ export const blockToAngular = ({
     }
 
     const stringifiedBindings = Object.entries(json.bindings)
+      .filter(([key]) => {
+        return !json.slots || !json.slots[key];
+      })
       .map(stringifyBinding(json, options, blockOptions))
       .join('');
 
@@ -487,6 +491,16 @@ export const blockToAngular = ({
       str += json.children
         .map((item) => blockToAngular({ root, json: item, options, blockOptions }))
         .join('\n');
+    }
+
+    if (json.slots) {
+      for (const [key, children] of Object.entries(json.slots)) {
+        str += `
+<ng-container ${dashCase(key)}>
+${children.map((item) => blockToAngular({ root, json: item, options, blockOptions })).join('')}
+</ng-container>
+`;
+      }
     }
 
     str += `</${element}>`;

--- a/packages/core/src/generators/angular/signals/blocks.ts
+++ b/packages/core/src/generators/angular/signals/blocks.ts
@@ -4,6 +4,7 @@ import { parseSelector } from '@/generators/angular/helpers/parse-selector';
 import { AngularBlockOptions, ToAngularOptions } from '@/generators/angular/types';
 import { babelTransformExpression } from '@/helpers/babel-transform';
 import { createSingleBinding } from '@/helpers/bindings';
+import { dashCase } from '@/helpers/dash-case';
 import {
   checkIsBindingNativeEvent,
   checkIsEvent,
@@ -449,6 +450,9 @@ export const blockToAngularSignals = ({
   }
 
   const stringifiedBindings = Object.entries(json.bindings)
+    .filter(([key]) => {
+      return !json.slots || !json.slots[key];
+    })
     .map(stringifyBinding(json, blockOptions, root))
     .join('');
 
@@ -468,6 +472,18 @@ export const blockToAngularSignals = ({
     str += json.children
       .map((item) => blockToAngularSignals({ root, json: item, options, blockOptions }))
       .join('\n');
+  }
+
+  if (json.slots) {
+    for (const [key, children] of Object.entries(json.slots)) {
+      str += `
+<ng-container ${dashCase(key)}>
+${children
+  .map((item) => blockToAngularSignals({ root, json: item, options, blockOptions }))
+  .join('')}
+</ng-container>
+`;
+    }
   }
 
   str += `</${element}>`;

--- a/packages/core/src/generators/stencil/blocks.ts
+++ b/packages/core/src/generators/stencil/blocks.ts
@@ -101,8 +101,11 @@ export const blockToStencil = ({
     // Stencil uses ´htmlFor´ (JSX) instead of ´for´ (HTML)
     str += ` ${transformAttributeToJSX(key)}="${value}" `;
   }
-  for (const key in json.bindings) {
-    const { code, arguments: cusArgs = [], type } = json.bindings[key]!;
+
+  for (const [key, value] of Object.entries(json.bindings).filter(([key]) => {
+    return !json.slots || !json.slots[key];
+  })) {
+    const { code, arguments: cusArgs = [], type } = value!;
     if (type === 'spread') {
       str += ` {...(${code})} `;
     } else if (key === 'ref') {
@@ -132,6 +135,26 @@ export const blockToStencil = ({
         }),
       )
       .join('\n');
+  }
+
+  if (json.slots) {
+    for (const [key, children] of Object.entries(json.slots)) {
+      str += `
+${children
+  .map((item) =>
+    blockToStencil({
+      json: {
+        ...item,
+        properties: { ...item.properties, slot: key },
+      },
+      options,
+      insideJsx: true,
+      childComponents,
+    }),
+  )
+  .join('')}
+`;
+    }
   }
 
   str += `</${blockName}>`;

--- a/packages/core/src/generators/vue/blocks.ts
+++ b/packages/core/src/generators/vue/blocks.ts
@@ -1,4 +1,5 @@
 import { createSingleBinding } from '@/helpers/bindings';
+import { dashCase } from '@/helpers/dash-case';
 import { checkIsEvent } from '@/helpers/event-handlers';
 import { filterEmptyTextNodes } from '@/helpers/filter-empty-text-nodes';
 import isChildren from '@/helpers/is-children';
@@ -201,6 +202,9 @@ const getBlockBindings = (node: MitosisNode, options: ToVueOptions) => {
     .join(' ');
 
   const stringifiedBindings = Object.entries(node.bindings as Dictionary<Binding>)
+    .filter(([key]) => {
+      return !node.slots || !node.slots[key];
+    })
     .map(stringifyBinding(node, options))
     .join(' ');
 
@@ -255,6 +259,16 @@ export const blockToVue: BlockRenderer = (node, options, scope) => {
   str += '>';
   if (node.children) {
     str += node.children.map((item) => blockToVue(item, options)).join('');
+  }
+
+  if (node.slots) {
+    for (const [key, children] of Object.entries(node.slots)) {
+      str += `
+<template #${dashCase(key)}>
+${children.map((item) => blockToVue(item, options)).join('')}
+</template>
+`;
+    }
   }
 
   return str + `</${node.name}>`;


### PR DESCRIPTION
## Description

Please provide the following information:

- What changes you made:

fixed nested slots inside Mitosis components

- Why you made them, and:

The slot was generated as attribute binding, but this might only the case in JSX based languages. Angular, Stencil and Vue using the default HTML slot syntax, which requires to add it as children with the `slot` attribute.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [X] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
