### PR TITLE
refactor: Enhance Button HTML attributes with Invoker Commands API

### DIFF
--- a/.changeset/tricky-carrots-try.md
+++ b/.changeset/tricky-carrots-try.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/mitosis": patch
+---
+
+refactor: Enhance Button HTML attributes with Invoker Commands API

--- a/.changeset/tricky-carrots-try.md
+++ b/.changeset/tricky-carrots-try.md
@@ -1,5 +1,5 @@
 ---
-"@builder.io/mitosis": patch
+"@builder.io/mitosis": minor
 ---
 
-refactor: Enhance Button HTML attributes with Invoker Commands API
+feat: Enhance Button HTML attributes with Invoker Commands API

--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -353,37 +353,37 @@ export declare namespace JSX {
     cite?: string;
   }
 
-interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
-  autofocus?: boolean;
-  disabled?: boolean;
-  form?: string;
-  formaction?: string;
-  formenctype?: HTMLFormEncType;
-  formmethod?: HTMLFormMethod;
-  formnovalidate?: boolean;
-  formtarget?: string;
-  name?: string;
-  type?: 'submit' | 'reset' | 'button';
-  value?: string;
+  interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+    autofocus?: boolean;
+    disabled?: boolean;
+    form?: string;
+    formaction?: string;
+    formenctype?: HTMLFormEncType;
+    formmethod?: HTMLFormMethod;
+    formnovalidate?: boolean;
+    formtarget?: string;
+    name?: string;
+    type?: 'submit' | 'reset' | 'button';
+    value?: string;
+    
+    // Invoker Commands API
+    command?: 
+      | 'show-modal'
+      | 'close'
+      | 'show-popover'
+      | 'hide-popover'
+      | 'toggle-popover'
+      | string;
+    commandfor?: string;
   
-  // Invoker Commands API
-  command?: 
-    | 'show-modal'
-    | 'close'
-    | 'show-popover'
-    | 'hide-popover'
-    | 'toggle-popover'
-    | string;
-  commandfor?: string;
-
-  // camelcase
-  formAction?: string;
-  formEnctype?: HTMLFormEncType;
-  formMethod?: HTMLFormMethod;
-  formNoValidate?: boolean;
-  formTarget?: string;
-  commandFor?: string;
-}
+    // camelcase
+    formAction?: string;
+    formEnctype?: HTMLFormEncType;
+    formMethod?: HTMLFormMethod;
+    formNoValidate?: boolean;
+    formTarget?: string;
+    commandFor?: string;
+  }
 
   interface CanvasHTMLAttributes<T> extends HTMLAttributes<T> {
     width?: number | string;

--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -353,26 +353,37 @@ export declare namespace JSX {
     cite?: string;
   }
 
-  interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
-    autofocus?: boolean;
-    disabled?: boolean;
-    form?: string;
-    formaction?: string;
-    formenctype?: HTMLFormEncType;
-    formmethod?: HTMLFormMethod;
-    formnovalidate?: boolean;
-    formtarget?: string;
-    name?: string;
-    type?: 'submit' | 'reset' | 'button';
-    value?: string;
+interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+  autofocus?: boolean;
+  disabled?: boolean;
+  form?: string;
+  formaction?: string;
+  formenctype?: HTMLFormEncType;
+  formmethod?: HTMLFormMethod;
+  formnovalidate?: boolean;
+  formtarget?: string;
+  name?: string;
+  type?: 'submit' | 'reset' | 'button';
+  value?: string;
+  
+  // Invoker Commands API
+  command?: 
+    | 'show-modal'
+    | 'close'
+    | 'show-popover'
+    | 'hide-popover'
+    | 'toggle-popover'
+    | string;
+  commandfor?: string;
 
-    // camelcase
-    formAction?: string;
-    formEnctype?: HTMLFormEncType;
-    formMethod?: HTMLFormMethod;
-    formNoValidate?: boolean;
-    formTarget?: string;
-  }
+  // camelcase
+  formAction?: string;
+  formEnctype?: HTMLFormEncType;
+  formMethod?: HTMLFormMethod;
+  formNoValidate?: boolean;
+  formTarget?: string;
+  commandFor?: string;
+}
 
   interface CanvasHTMLAttributes<T> extends HTMLAttributes<T> {
     width?: number | string;

--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -365,17 +365,11 @@ export declare namespace JSX {
     name?: string;
     type?: 'submit' | 'reset' | 'button';
     value?: string;
-    
+
     // Invoker Commands API
-    command?: 
-      | 'show-modal'
-      | 'close'
-      | 'show-popover'
-      | 'hide-popover'
-      | 'toggle-popover'
-      | string;
+    command?: 'show-modal' | 'close' | 'show-popover' | 'hide-popover' | 'toggle-popover' | string;
     commandfor?: string;
-  
+
     // camelcase
     formAction?: string;
     formEnctype?: HTMLFormEncType;

--- a/packages/core/src/helpers/is-html-attribute.ts
+++ b/packages/core/src/helpers/is-html-attribute.ts
@@ -75,6 +75,8 @@ export const htmlElementAttributes: { [key: string]: string[] } = {
   body: ['alink', 'background', 'bgcolor', 'link', 'text', 'vlink'],
   br: ['clear'],
   button: [
+    'command',
+    'commandfor',
     'disabled',
     'form',
     'formaction',
@@ -85,8 +87,6 @@ export const htmlElementAttributes: { [key: string]: string[] } = {
     'name',
     'type',
     'value',
-    'command',
-    'commandfor',
   ],
   canvas: ['height', 'width'],
   caption: ['align'],

--- a/packages/core/src/helpers/is-html-attribute.ts
+++ b/packages/core/src/helpers/is-html-attribute.ts
@@ -85,6 +85,8 @@ export const htmlElementAttributes: { [key: string]: string[] } = {
     'name',
     'type',
     'value',
+    'command',
+    'commandfor',
   ],
   canvas: ['height', 'width'],
   caption: ['align'],


### PR DESCRIPTION
## Description

Please provide the following information:

- What changes you made:
Added [`command`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#command) and [`commandFor`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#commandfor)-HTML-attributes to `ButtonHTMLAttributes` interface and HTML attributes list.
- Why you made them, and:
Keep up with the web standards.
- ~Any other useful context:~

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
