### PR TITLE
fix: resolve missing `style` attribute passing for Angular and Stenci…

### DIFF
--- a/.changeset/late-goats-retire.md
+++ b/.changeset/late-goats-retire.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+fix: issue with missing `style` attribute passing for angular and stencil

--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -3693,9 +3693,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -3703,14 +3703,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -3724,6 +3719,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -3779,9 +3777,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -3789,14 +3787,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -3810,6 +3803,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -12063,9 +12059,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -12076,14 +12072,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -12097,6 +12088,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -12152,9 +12146,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -12165,14 +12159,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -12186,6 +12175,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }

--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -3719,7 +3719,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -3803,7 +3807,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -12088,7 +12096,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -12175,7 +12187,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -3771,7 +3771,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -3856,7 +3860,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -12280,7 +12288,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -12368,7 +12380,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -3745,9 +3745,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -3755,14 +3755,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -3776,6 +3771,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -3832,9 +3830,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -3842,14 +3840,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -3863,6 +3856,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -12255,9 +12251,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -12268,14 +12264,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -12289,6 +12280,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -12345,9 +12339,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -12358,14 +12352,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -12379,6 +12368,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }

--- a/packages/core/src/__tests__/__snapshots__/angular.signals.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.signals.test.ts.snap
@@ -3262,9 +3262,9 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
   constructor() {}
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -3275,14 +3275,9 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -3296,6 +3291,9 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -3345,9 +3343,9 @@ export class BasicRefAttributePassingCustomRefComponent
   constructor() {}
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -3358,14 +3356,9 @@ export class BasicRefAttributePassingCustomRefComponent
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -3379,6 +3372,9 @@ export class BasicRefAttributePassingCustomRefComponent
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -10385,9 +10381,9 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
   constructor() {}
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -10398,14 +10394,9 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -10419,6 +10410,9 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -10468,9 +10462,9 @@ export class BasicRefAttributePassingCustomRefComponent
   constructor() {}
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -10481,14 +10475,9 @@ export class BasicRefAttributePassingCustomRefComponent
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -10502,6 +10491,9 @@ export class BasicRefAttributePassingCustomRefComponent
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }

--- a/packages/core/src/__tests__/__snapshots__/angular.signals.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.signals.test.ts.snap
@@ -3291,7 +3291,11 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -3372,7 +3376,11 @@ export class BasicRefAttributePassingCustomRefComponent
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -10410,7 +10418,11 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -10491,7 +10503,11 @@ export class BasicRefAttributePassingCustomRefComponent
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }

--- a/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
@@ -3842,9 +3842,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -3852,14 +3852,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -3873,6 +3868,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -3928,9 +3926,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -3938,14 +3936,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -3959,6 +3952,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -12538,9 +12534,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -12551,14 +12547,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -12572,6 +12563,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -12627,9 +12621,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -12640,14 +12634,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -12661,6 +12650,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }

--- a/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
@@ -3868,7 +3868,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -3952,7 +3956,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -12563,7 +12571,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -12650,7 +12662,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }

--- a/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
@@ -3358,9 +3358,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -3368,14 +3368,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -3389,6 +3384,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -3437,9 +3435,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -3447,14 +3445,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -3468,6 +3461,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -10832,9 +10828,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -10845,14 +10841,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -10866,6 +10857,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -10914,9 +10908,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -10927,14 +10921,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -10948,6 +10937,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }

--- a/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
@@ -3384,7 +3384,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -3461,7 +3465,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -10857,7 +10865,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -10937,7 +10949,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -7043,9 +7043,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -7053,14 +7053,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -7074,6 +7069,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -7131,9 +7129,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -7141,14 +7139,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -7162,6 +7155,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -7210,9 +7206,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -7220,14 +7216,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -7241,6 +7232,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -7291,9 +7285,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
@@ -7301,14 +7295,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -7322,6 +7311,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -22911,9 +22903,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -22924,14 +22916,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -22945,6 +22932,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -23002,9 +22992,9 @@ export default class BasicRefAttributePassingComponent {
   @ViewChild(\\"_root\\") _root!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -23015,14 +23005,9 @@ export default class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -23036,6 +23021,9 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -23084,9 +23072,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -23097,14 +23085,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -23118,6 +23101,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -23168,9 +23154,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   @ViewChild(\\"buttonRef\\") buttonRef!: ElementRef;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -23181,14 +23167,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -23202,6 +23183,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -7069,7 +7069,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -7155,7 +7159,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -7232,7 +7240,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -7311,7 +7323,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -22932,7 +22948,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -23021,7 +23041,11 @@ export default class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -23101,7 +23125,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -23183,7 +23211,11 @@ export default class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -2392,7 +2392,11 @@ export class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -2468,7 +2472,11 @@ export class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -7010,7 +7018,11 @@ export class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }
@@ -7086,7 +7098,11 @@ export class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith(\\"_\\")) {
+        } else if (
+          attr.name === \\"style\\" ||
+          attr.name.startsWith(\\"data-\\") ||
+          attr.name.startsWith(\\"aria-\\")
+        ) {
           element.setAttribute(attr.name, attr.value);
           parent.removeAttribute(attr.name);
         }

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -2363,9 +2363,9 @@ export class BasicRefAttributePassingComponent {
   private _root!: HTMLElement;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -2376,14 +2376,9 @@ export class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -2397,6 +2392,9 @@ export class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -2441,9 +2439,9 @@ export class BasicRefAttributePassingCustomRefComponent {
   private buttonRef!: HTMLElement;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -2454,14 +2452,9 @@ export class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -2475,6 +2468,9 @@ export class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -6985,9 +6981,9 @@ export class BasicRefAttributePassingComponent {
   private _root!: HTMLElement;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -6998,14 +6994,9 @@ export class BasicRefAttributePassingComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -7019,6 +7010,9 @@ export class BasicRefAttributePassingComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }
@@ -7063,9 +7057,9 @@ export class BasicRefAttributePassingCustomRefComponent {
   private buttonRef!: HTMLButtonElement | null;
 
   /**
-   * Passes \`aria-*\`, \`data-*\` & \`class\` attributes to correct child. Used in angular and stencil.
+   * Passes attributes to correct child. Used in angular and stencil.
    * @param element  the ref for the component
-   * @param customElementSelector  the custom element like \`my-component\`
+   * @param customElementSelector the custom element like \`my-component\`
    */
   private enableAttributePassing(
     element: HTMLElement | null,
@@ -7076,14 +7070,9 @@ export class BasicRefAttributePassingCustomRefComponent {
       const attributes = parent.attributes;
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes.item(i);
-        if (
-          attr &&
-          (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
-        ) {
-          element.setAttribute(attr.name, attr.value);
-          parent.removeAttribute(attr.name);
-        }
-        if (attr && attr.name === \\"class\\") {
+        if (!attr) continue;
+
+        if (attr.name === \\"class\\") {
           const isWebComponent = attr.value.includes(\\"hydrated\\");
           const value = attr.value.replace(\\"hydrated\\", \\"\\").trim();
           const currentClass = element.getAttribute(\\"class\\");
@@ -7097,6 +7086,9 @@ export class BasicRefAttributePassingCustomRefComponent {
           } else {
             parent.removeAttribute(attr.name);
           }
+        } else if (!attr.name.startsWith(\\"_\\")) {
+          element.setAttribute(attr.name, attr.value);
+          parent.removeAttribute(attr.name);
         }
       }
     }

--- a/packages/core/src/generators/angular/classic/component.ts
+++ b/packages/core/src/generators/angular/classic/component.ts
@@ -350,7 +350,7 @@ export const componentToAngularClassic: TranspilerGenerator<ToAngularOptions> = 
             withAttributePassing
               ? getAttributePassingString(
                   options.typescript,
-                  json.meta.useMetadata?.attributePassing?.exceptions,
+                  json.meta.useMetadata?.attributePassing?.additional,
                 )
               : ''
           }

--- a/packages/core/src/generators/angular/classic/component.ts
+++ b/packages/core/src/generators/angular/classic/component.ts
@@ -346,7 +346,14 @@ export const componentToAngularClassic: TranspilerGenerator<ToAngularOptions> = 
     
           ${!hasConstructor ? '' : `constructor(\n${constructorInjectables}) {}`}
           
-          ${withAttributePassing ? getAttributePassingString(options.typescript) : ''}
+          ${
+            withAttributePassing
+              ? getAttributePassingString(
+                  options.typescript,
+                  json.meta.useMetadata?.attributePassing?.exceptions,
+                )
+              : ''
+          }
           
           ${
             !json.hooks.onMount.length && !dynamicComponents.size && !json.hooks.onInit?.code

--- a/packages/core/src/generators/angular/signals/component.ts
+++ b/packages/core/src/generators/angular/signals/component.ts
@@ -416,7 +416,7 @@ Please add a initial value for every state property even if it's \`undefined\`.`
             withAttributePassing
               ? getAttributePassingString(
                   options.typescript,
-                  json.meta.useMetadata?.attributePassing?.exceptions,
+                  json.meta.useMetadata?.attributePassing?.additional,
                 )
               : ''
           }

--- a/packages/core/src/generators/angular/signals/component.ts
+++ b/packages/core/src/generators/angular/signals/component.ts
@@ -412,7 +412,14 @@ Please add a initial value for every state property even if it's \`undefined\`.`
                   `
           }}
           
-          ${withAttributePassing ? getAttributePassingString(options.typescript) : ''}
+          ${
+            withAttributePassing
+              ? getAttributePassingString(
+                  options.typescript,
+                  json.meta.useMetadata?.attributePassing?.exceptions,
+                )
+              : ''
+          }
           
           ${
             isHookEmpty(json.hooks.onInit)

--- a/packages/core/src/generators/stencil/component.ts
+++ b/packages/core/src/generators/stencil/component.ts
@@ -166,7 +166,7 @@ export const componentToStencil: TranspilerGenerator<ToStencilOptions> = (
           ${getExportsAndLocal(json)}
           ${
             withAttributePassing
-              ? getAttributePassingString(true, json.meta.useMetadata?.attributePassing?.exceptions)
+              ? getAttributePassingString(true, json.meta.useMetadata?.attributePassing?.additional)
               : ''
           }
           

--- a/packages/core/src/generators/stencil/component.ts
+++ b/packages/core/src/generators/stencil/component.ts
@@ -164,7 +164,11 @@ export const componentToStencil: TranspilerGenerator<ToStencilOptions> = (
           ${dataString}
           ${methodsString}
           ${getExportsAndLocal(json)}
-          ${withAttributePassing ? getAttributePassingString(true) : ''}
+          ${
+            withAttributePassing
+              ? getAttributePassingString(true, json.meta.useMetadata?.attributePassing?.exceptions)
+              : ''
+          }
           
           ${dependencyOnUpdateHooks
             .map((hook: BaseHook, index: number) => {

--- a/packages/core/src/helpers/web-components/attribute-passing.ts
+++ b/packages/core/src/helpers/web-components/attribute-passing.ts
@@ -33,7 +33,9 @@ const parent = element?.closest(customElementSelector);
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith('_')${exceptions?.length ? `&& ![${exceptions.join(",")}].includes(attr)`:""}) {
+        } else if (!attr.name.startsWith('_')${
+          exceptions?.length ? `&& ![${exceptions.join(',')}].includes(attr)` : ''
+        }) {
           element.setAttribute(attr.name, attr.value)
           parent.removeAttribute(attr.name);
         }

--- a/packages/core/src/helpers/web-components/attribute-passing.ts
+++ b/packages/core/src/helpers/web-components/attribute-passing.ts
@@ -3,7 +3,7 @@ import { BaseTranspilerOptions } from '@/types/transpiler';
 
 export const ROOT_REF = '_root';
 
-export const getAttributePassingString = (typescript?: boolean, exceptions?: string[]) => {
+export const getAttributePassingString = (typescript?: boolean, additional?: string[]) => {
   return `/**
  * Passes attributes to correct child. Used in angular and stencil.
  * @param element  the ref for the component
@@ -33,8 +33,8 @@ const parent = element?.closest(customElementSelector);
           } else {
             parent.removeAttribute(attr.name);
           }
-        } else if (!attr.name.startsWith('_')${
-          exceptions?.length ? `&& ![${exceptions.join(',')}].includes(attr)` : ''
+        } else if (attr.name === 'style' || attr.name.startsWith('data-') || attr.name.startsWith('aria-')${
+          additional?.length ? `&& [${additional.join(',')}].includes(attr)` : ''
         }) {
           element.setAttribute(attr.name, attr.value)
           parent.removeAttribute(attr.name);

--- a/packages/core/src/helpers/web-components/attribute-passing.ts
+++ b/packages/core/src/helpers/web-components/attribute-passing.ts
@@ -3,42 +3,43 @@ import { BaseTranspilerOptions } from '@/types/transpiler';
 
 export const ROOT_REF = '_root';
 
-export const getAttributePassingString = (typescript?: boolean) => {
-  return (
-    '/**\n' +
-    ' * Passes `aria-*`, `data-*` & `class` attributes to correct child. Used in angular and stencil.\n' +
-    ' * @param element  the ref for the component\n' +
-    ' * @param customElementSelector  the custom element like `my-component`\n' +
-    ' */\n' +
-    `private enableAttributePassing(element${
-      typescript ? ': HTMLElement | null' : ''
-    }, customElementSelector${typescript ? ': string' : ''}) {
-` +
-    '  const parent = element?.closest(customElementSelector);\n' +
-    '  if (element && parent) {\n' +
-    '    const attributes = parent.attributes;\n' +
-    '    for (let i = 0; i < attributes.length; i++) {\n' +
-    '      const attr = attributes.item(i);\n' +
-    "      if (attr && (attr.name.startsWith('data-') || attr.name.startsWith('aria-'))) {\n" +
-    '        element.setAttribute(attr.name, attr.value);\n' +
-    '        parent.removeAttribute(attr.name);\n' +
-    '      }\n' +
-    "      if (attr && attr.name === 'class') {\n" +
-    "        const isWebComponent = attr.value.includes('hydrated');\n" +
-    "        const value = attr.value.replace('hydrated', '').trim();\n" +
-    "        const currentClass = element.getAttribute('class');\n" +
-    "        element.setAttribute(attr.name, `${currentClass ? `${currentClass} ` : ''}${value}`);\n" +
-    '        if (isWebComponent) {\n' +
-    '          // Stencil is using this class for lazy loading component\n' +
-    "          parent.setAttribute('class', 'hydrated');\n" +
-    '        } else {\n' +
-    '          parent.removeAttribute(attr.name);\n' +
-    '        }\n' +
-    '      }\n' +
-    '    }\n' +
-    '  }\n' +
-    '};'
-  );
+export const getAttributePassingString = (typescript?: boolean, exceptions?: string[]) => {
+  return `/**
+ * Passes attributes to correct child. Used in angular and stencil.
+ * @param element  the ref for the component
+ * @param customElementSelector the custom element like \`my-component\`
+ */
+private enableAttributePassing(element${
+    typescript ? ': HTMLElement | null' : ''
+  }, customElementSelector${typescript ? ': string' : ''}) {
+const parent = element?.closest(customElementSelector);
+    if (element && parent) {
+      const attributes = parent.attributes;
+      for (let i = 0; i < attributes.length; i++) {
+        const attr = attributes.item(i);
+        if (!attr) continue;
+
+        if (attr.name === 'class') {
+          const isWebComponent = attr.value.includes('hydrated');
+          const value = attr.value.replace('hydrated', '').trim();
+          const currentClass = element.getAttribute('class');
+          element.setAttribute(
+            attr.name,     
+            \`\${currentClass ? \`\${currentClass} \` : ''}\${value}\`
+          );
+          if (isWebComponent) {
+            // Stencil is using this class for lazy loading component
+            parent.setAttribute('class', 'hydrated');
+          } else {
+            parent.removeAttribute(attr.name);
+          }
+        } else if (!attr.name.startsWith('_')${exceptions?.length ? `&& ![${exceptions.join(",")}].includes(attr)`:""}) {
+          element.setAttribute(attr.name, attr.value)
+          parent.removeAttribute(attr.name);
+        }
+      }
+    }
+};`;
 };
 
 export const shouldAddAttributePassing = (json: MitosisComponent, options: BaseTranspilerOptions) =>

--- a/packages/core/src/types/transpiler.ts
+++ b/packages/core/src/types/transpiler.ts
@@ -18,6 +18,7 @@ export type TranspilerGenerator<X extends BaseTranspilerOptions, Y = string> = (
 export type AttributePassingType = {
   enabled: boolean;
   customRef?: string;
+  exceptions?: string[];
 };
 
 export interface BaseTranspilerOptions {

--- a/packages/core/src/types/transpiler.ts
+++ b/packages/core/src/types/transpiler.ts
@@ -16,9 +16,12 @@ export type TranspilerGenerator<X extends BaseTranspilerOptions, Y = string> = (
 ) => Transpiler<Y>;
 
 export type AttributePassingType = {
+  /** enable/disable attribute passing */
   enabled: boolean;
+  /** Custom ref name to use instead of `_ref` */
   customRef?: string;
-  exceptions?: string[];
+  /** Custom attributes to always pass through */
+  additional?: string[];
 };
 
 export interface BaseTranspilerOptions {


### PR DESCRIPTION
…l components

## Description

Please provide the following information:

At the moment you can enable `attributePassing` for Angular and Stencil, but it doesn't pass every property like `style`

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
