### PR TITLE
fix: publish workflow failing due to invalid github token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BUILDER_BOT_FOR_LINT_APP_ID }}
+          private-key: ${{ secrets.BUILDER_BOT_FOR_LINT_PRIVATE_KEY }}
+
       - name: Setup
         uses: actions/checkout@v4
         with:
-          # need this custom token to run CI checks on the created PR
-          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          # need this token to run CI checks on the created PR
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -41,8 +48,8 @@ jobs:
           title: '📦 Publish Mitosis'
           commit: '📦 Publish Mitosis'
         env:
-          # need this custom token to run CI checks on the created PR
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          # need this token to run CI checks on the created PR
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
           # probably don't need both of those, but it works!
           NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}


### PR DESCRIPTION
## Description
- The publish package workflow is failing with following errror ([failing job](https://github.com/BuilderIO/mitosis/actions/runs/26879653272/job/79279251637))
<img width="1112" height="568" alt="image" src="https://github.com/user-attachments/assets/f0a71d55-a53d-44a2-a780-4a1336b4b1f6" />

- I have made the same fix as followed in the builder repo for the same issue -  https://github.com/BuilderIO/builder/pull/4371

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
