### PR TITLE
fix: npm CI publishing to use OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22 # OIDC trusted publishing requires Node >= 22.14.0
+          registry-url: 'https://registry.npmjs.org'
 
       - name: 📥 Monorepo install
         uses: ./.github/actions/yarn-nm-install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  id-token: write # Required for npm OIDC trusted publishing
+  contents: read
+
 jobs:
   publish-sdks:
     name: Publish package
@@ -40,6 +44,11 @@ jobs:
           cache-node-modules: true
           cache-install-state: true
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: |
+          npm install -g npm@11.5.1 # minimum version supporting OIDC trusted publishing
+          npm --version
+
       - name: Create Release PR & Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -50,7 +59,3 @@ jobs:
         env:
           # need this token to run CI checks on the created PR
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-
-          # probably don't need both of those, but it works!
-          NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22 # OIDC trusted publishing requires Node >= 22.14.0
-          registry-url: 'https://registry.npmjs.org'
 
       - name: 📥 Monorepo install
         uses: ./.github/actions/yarn-nm-install


### PR DESCRIPTION
## Description
- Following the fix from ai-services for the same issue - https://github.com/BuilderIO/ai-services/pull/5249

Issue -> PUT is failing for package
<img width="1121" height="770" alt="image" src="https://github.com/user-attachments/assets/e1fa4ba8-5798-41ca-983e-a0195a5653c2" />

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
