### PR TITLE
refactor: added `closedby` property

### DIFF
--- a/.changeset/quick-dogs-smell.md
+++ b/.changeset/quick-dogs-smell.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+added closedby property

--- a/.changeset/quick-dogs-smell.md
+++ b/.changeset/quick-dogs-smell.md
@@ -2,4 +2,4 @@
 '@builder.io/mitosis': patch
 ---
 
-added closedby property
+feat(`dialog`): added `closedby` property

--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -402,11 +402,7 @@ export declare namespace JSX {
   interface DialogHtmlAttributes<T> extends HTMLAttributes<T> {
     open?: boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/closedby) */
-    closedby?: string;
-
-    // camelcase
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/closedby) */
-    closedBy?: string;
+    closedby?: 'any' | 'closerequest' | 'none';
   }
 
   interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {

--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -401,6 +401,12 @@ export declare namespace JSX {
 
   interface DialogHtmlAttributes<T> extends HTMLAttributes<T> {
     open?: boolean;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/closedby) */
+    closedby?: string;
+
+    // camelcase
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/closedby) */
+    closedBy?: string;
   }
 
   interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {

--- a/packages/core/src/generators/lit/generate.ts
+++ b/packages/core/src/generators/lit/generate.ts
@@ -22,10 +22,10 @@ import { camelCase, some } from 'lodash';
 import { format } from 'prettier/standalone';
 import { SELF_CLOSING_HTML_TAGS } from '../../constants/html_tags';
 import {
-    runPostCodePlugins,
-    runPostJsonPlugins,
-    runPreCodePlugins,
-    runPreJsonPlugins,
+  runPostCodePlugins,
+  runPostJsonPlugins,
+  runPreCodePlugins,
+  runPreJsonPlugins,
 } from '../../modules/plugins';
 import { stringifySingleScopeOnMount } from '../helpers/on-mount';
 import { collectClassString } from './collect-class-string';
@@ -115,7 +115,8 @@ const blockToLit = (json: MitosisNode, options: ToLitOptions = {}): string => {
       } else {
         // TODO: handle boolean attributes too by matching list of html boolean attributes
         // https://lit.dev/docs/templates/expressions/#boolean-attribute-expressions
-        const propKey = ATTR_TO_PROP.get(key) ?? key;
+        const isNativeElement = !json.name.includes('-') && !isUpperCase(json.name[0]);
+        const propKey = isNativeElement ? ATTR_TO_PROP.get(key) ?? key : key;
         str += ` .${propKey}=\${${value}} `;
       }
     }

--- a/packages/core/src/generators/lit/generate.ts
+++ b/packages/core/src/generators/lit/generate.ts
@@ -22,13 +22,20 @@ import { camelCase, some } from 'lodash';
 import { format } from 'prettier/standalone';
 import { SELF_CLOSING_HTML_TAGS } from '../../constants/html_tags';
 import {
-  runPostCodePlugins,
-  runPostJsonPlugins,
-  runPreCodePlugins,
-  runPreJsonPlugins,
+    runPostCodePlugins,
+    runPostJsonPlugins,
+    runPreCodePlugins,
+    runPreJsonPlugins,
 } from '../../modules/plugins';
 import { stringifySingleScopeOnMount } from '../helpers/on-mount';
 import { collectClassString } from './collect-class-string';
+
+/**
+ * Maps lowercase HTML attribute names to their corresponding camelCase DOM property names
+ * where the two differ. Needed because Lit property bindings (`.prop=${val}`) must use
+ * the actual DOM property name.
+ */
+const ATTR_TO_PROP = new Map<string, string>([['closedby', 'closedBy']]);
 
 const getCustomTagName = (name: string, options: ToLitOptions) => {
   if (!name || !isUpperCase(name[0])) {
@@ -108,7 +115,8 @@ const blockToLit = (json: MitosisNode, options: ToLitOptions = {}): string => {
       } else {
         // TODO: handle boolean attributes too by matching list of html boolean attributes
         // https://lit.dev/docs/templates/expressions/#boolean-attribute-expressions
-        str += ` .${key}=\${${value}} `;
+        const propKey = ATTR_TO_PROP.get(key) ?? key;
+        str += ` .${propKey}=\${${value}} `;
       }
     }
   }

--- a/packages/core/src/helpers/is-html-attribute.ts
+++ b/packages/core/src/helpers/is-html-attribute.ts
@@ -93,7 +93,7 @@ export const htmlElementAttributes: { [key: string]: string[] } = {
   data: ['value'],
   del: ['cite', 'datetime'],
   details: ['open'],
-  dialog: ['open', 'closedby'],
+  dialog: ['closedby', 'open'],
   dir: ['compact'],
   div: ['align'],
   dl: ['compact'],

--- a/packages/core/src/helpers/is-html-attribute.ts
+++ b/packages/core/src/helpers/is-html-attribute.ts
@@ -93,7 +93,7 @@ export const htmlElementAttributes: { [key: string]: string[] } = {
   data: ['value'],
   del: ['cite', 'datetime'],
   details: ['open'],
-  dialog: ['open'],
+  dialog: ['open', 'closedby'],
   dir: ['compact'],
   div: ['align'],
   dl: ['compact'],


### PR DESCRIPTION
## Description

Please provide the following information:

- What changes you made:

Added entires of new `closedby` properties on `dialog` HTML element.

Even also addressed Codex feedback:
>  Map lowercase closedby for Lit bindings
> When a typed Mitosis component uses the standard lowercase attribute with a dynamic value, e.g. `<dialog closedby={mode}>`, the parser preserves the key and the Lit generator forces any binding without a dash into a property binding (`packages/core/src/generators/lit/generate.ts:108-112`). [MDN documents](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/closedBy) the reflected DOM property as `closedBy`, not `closedby`, so Lit emits `.closedby=${...}` and assigns an inert expando property instead of updating the dialog's close behavior; either map this key for Lit or avoid exposing the lowercase spelling for bindings.

> Scope closedby remapping to native dialogs
> When generating Lit for a custom component/custom element with a lowercase `closedby` prop, e.g. `<MyDialog closedby={mode}>`, this binding loop does not check `json.name`, so it rewrites the prop to `.closedBy` on `<my-dialog>`. Mitosis otherwise passes custom-element props by their exact property names, and JS/Lit property names are case-sensitive, so the child’s `closedby` prop will no longer receive updates; apply this alias only for native `dialog` nodes.

Useful? React with 👍 / 👎.

- Why you made them, and:

To keep up with the Web Standards development.

- Any other useful context:

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
