### PR TITLE
fix(NG & WC): attribute passing removals

### DIFF
--- a/.changeset/blue-papayas-happen.md
+++ b/.changeset/blue-papayas-happen.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/mitosis": patch
+---
+
+fix(Angular & Stencil): attribute passing removals

--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -3700,9 +3700,9 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -3786,9 +3786,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -12073,9 +12073,9 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -12162,9 +12162,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -3752,9 +3752,9 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -3839,9 +3839,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -12265,9 +12265,9 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -12355,9 +12355,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))

--- a/packages/core/src/__tests__/__snapshots__/angular.signals.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.signals.test.ts.snap
@@ -3285,9 +3285,9 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -3369,9 +3369,9 @@ export class BasicRefAttributePassingCustomRefComponent
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -10466,9 +10466,9 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -10550,9 +10550,9 @@ export class BasicRefAttributePassingCustomRefComponent
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))

--- a/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
@@ -3849,9 +3849,9 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -3935,9 +3935,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -12548,9 +12548,9 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -12637,9 +12637,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))

--- a/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
@@ -3365,9 +3365,9 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -3444,9 +3444,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -10842,9 +10842,9 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -10924,9 +10924,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -7050,9 +7050,9 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -7138,9 +7138,9 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -7217,9 +7217,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -7298,9 +7298,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -22921,9 +22921,9 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -23012,9 +23012,9 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -23094,9 +23094,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -23178,9 +23178,9 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -2373,9 +2373,9 @@ export class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -2451,9 +2451,9 @@ export class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -6995,9 +6995,9 @@ export class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))
@@ -7073,9 +7073,9 @@ export class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = parent.attributes;
+      const attributes = [...parent.attributes];
       for (let i = 0; i < attributes.length; i++) {
-        const attr = attributes.item(i);
+        const attr = attributes[i];
         if (
           attr &&
           (attr.name.startsWith(\\"data-\\") || attr.name.startsWith(\\"aria-\\"))

--- a/packages/core/src/helpers/web-components/attribute-passing.test.ts
+++ b/packages/core/src/helpers/web-components/attribute-passing.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import { getAttributePassingString } from './attribute-passing';
+
+/**
+ * Creates a minimal DOM-like element mock that simulates the live NamedNodeMap behavior.
+ * The key insight: `element.attributes` in real DOM returns a LIVE NamedNodeMap object.
+ * If you hold a reference to it, its `.length` and `.item(i)` change as attributes are removed.
+ */
+function createMockElement(tagName: string, attrs: Record<string, string>) {
+  const attrStore = new Map(Object.entries(attrs));
+
+  // A live NamedNodeMap proxy — the SAME object is returned each time .attributes is accessed,
+  // and its length/item reflect the current state of attrStore.
+  const liveNamedNodeMap = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        const entries = [...attrStore.entries()].map(([name, value]) => ({ name, value }));
+        if (prop === 'length') return entries.length;
+        if (prop === 'item') return (i: number) => entries[i] ?? null;
+        if (prop === Symbol.iterator) return () => entries[Symbol.iterator]();
+        // Numeric index access
+        if (typeof prop === 'string' && !isNaN(Number(prop))) {
+          return entries[Number(prop)] ?? undefined;
+        }
+        return undefined;
+      },
+    },
+  );
+
+  const element = {
+    tagName,
+    getAttribute(name: string) {
+      return attrStore.get(name) ?? null;
+    },
+    setAttribute(name: string, value: string) {
+      attrStore.set(name, value);
+    },
+    removeAttribute(name: string) {
+      attrStore.delete(name);
+    },
+    /** Returns the same live proxy object each time — just like real DOM */
+    get attributes() {
+      return liveNamedNodeMap as any;
+    },
+    closest(_selector: string) {
+      // Will be wired up in test
+      return null as any;
+    },
+  };
+
+  return element;
+}
+
+/**
+ * Builds the enableAttributePassing function from the generated string and executes it
+ * in a controlled environment, returning the state of parent and child after execution.
+ */
+function runAttributePassing(
+  parentAttrs: Record<string, string>,
+  childAttrs: Record<string, string>,
+) {
+  const parent = createMockElement('db-stack', parentAttrs);
+  const child = createMockElement('div', childAttrs);
+
+  // Wire up closest() so child.closest('db-stack') returns the parent
+  child.closest = (_selector: string) => parent;
+
+  // Extract the function body from the generated code.
+  // The generated code is a class method, so we wrap it to be callable.
+  const generatedCode = getAttributePassingString(false);
+
+  // Build a standalone function from the generated method body
+  const fnBody = generatedCode
+    // Remove the method signature wrapper and JSDoc
+    .replace(/\/\*\*[\s\S]*?\*\/\s*/, '')
+    .replace(/private enableAttributePassing\(element, customElementSelector\) \{/, '')
+    .replace(/\};$/, '');
+
+  // Create and invoke the function with our mocks
+  const fn = new Function('element', 'customElementSelector', fnBody);
+  fn(child, 'db-stack');
+
+  // Collect remaining attributes
+  const parentResult: Record<string, string> = {};
+  for (const { name, value } of parent.attributes) {
+    parentResult[name] = value;
+  }
+  const childResult: Record<string, string> = {};
+  for (const { name, value } of child.attributes) {
+    childResult[name] = value;
+  }
+
+  return { parent: parentResult, child: childResult };
+}
+
+describe('enableAttributePassing runtime behavior', () => {
+  it('passes multiple data-* attributes from parent to child (regression: live NamedNodeMap)', () => {
+    // Reproduction case: <db-stack data-a="1" data-b="2"></db-stack>
+    // with a child <div class="db-stack"></div>
+    const { parent, child } = runAttributePassing(
+      { 'data-a': '1', 'data-b': '2' },
+      { class: 'db-stack' },
+    );
+
+    // Both data attributes must be moved to the child
+    expect(child['data-a']).toBe('1');
+    expect(child['data-b']).toBe('2');
+
+    // Both must be removed from the parent
+    expect(parent['data-a']).toBeUndefined();
+    expect(parent['data-b']).toBeUndefined();
+  });
+
+  it('passes aria-* attributes from parent to child', () => {
+    const { parent, child } = runAttributePassing(
+      { 'aria-label': 'Stack', 'aria-hidden': 'true' },
+      { class: 'db-stack' },
+    );
+
+    expect(child['aria-label']).toBe('Stack');
+    expect(child['aria-hidden']).toBe('true');
+    expect(parent['aria-label']).toBeUndefined();
+    expect(parent['aria-hidden']).toBeUndefined();
+  });
+
+  it('passes class attribute from parent to child', () => {
+    const { parent, child } = runAttributePassing({ class: 'custom-class' }, { class: 'db-stack' });
+
+    expect(child.class).toBe('db-stack custom-class');
+    expect(parent.class).toBeUndefined();
+  });
+
+  it('handles a mix of data-*, aria-*, class, and non-passable attributes', () => {
+    const { parent, child } = runAttributePassing(
+      { 'data-a': '1', 'aria-label': 'hello', class: 'extra', id: 'my-id' },
+      { class: 'db-stack' },
+    );
+
+    // data and aria are moved
+    expect(child['data-a']).toBe('1');
+    expect(child['aria-label']).toBe('hello');
+    // class is merged
+    expect(child.class).toBe('db-stack extra');
+    // id stays on the parent (not passable)
+    expect(parent.id).toBe('my-id');
+    // passable ones removed from parent
+    expect(parent['data-a']).toBeUndefined();
+    expect(parent['aria-label']).toBeUndefined();
+    expect(parent.class).toBeUndefined();
+  });
+
+  it('handles three or more data attributes without skipping any', () => {
+    const { parent, child } = runAttributePassing(
+      { 'data-x': 'a', 'data-y': 'b', 'data-z': 'c' },
+      {},
+    );
+
+    expect(child['data-x']).toBe('a');
+    expect(child['data-y']).toBe('b');
+    expect(child['data-z']).toBe('c');
+    expect(parent['data-x']).toBeUndefined();
+    expect(parent['data-y']).toBeUndefined();
+    expect(parent['data-z']).toBeUndefined();
+  });
+});

--- a/packages/core/src/helpers/web-components/attribute-passing.ts
+++ b/packages/core/src/helpers/web-components/attribute-passing.ts
@@ -16,9 +16,9 @@ export const getAttributePassingString = (typescript?: boolean) => {
 ` +
     '  const parent = element?.closest(customElementSelector);\n' +
     '  if (element && parent) {\n' +
-    '    const attributes = parent.attributes;\n' +
+    '    const attributes = [...parent.attributes];\n' +
     '    for (let i = 0; i < attributes.length; i++) {\n' +
-    '      const attr = attributes.item(i);\n' +
+    '      const attr = attributes[i];\n' +
     "      if (attr && (attr.name.startsWith('data-') || attr.name.startsWith('aria-'))) {\n" +
     '        element.setAttribute(attr.name, attr.value);\n' +
     '        parent.removeAttribute(attr.name);\n' +


### PR DESCRIPTION
## Description

Please provide the following information:

### What changes you made:

**Fix** (in `attribute-passing.ts`, 2 lines changed):
1. `const attributes = parent.attributes;` → `const attributes = [...parent.attributes];` — creates a static snapshot before iterating
2. `const attr = attributes.item(i);` → `const attr = attributes[i];` — uses standard array indexing on the now-static array

**Test** (new file `attribute-passing.test.ts`):
- Uses a `Proxy`-based mock that faithfully simulates the live `NamedNodeMap` behavior (length/indexing reflect mutations in real time)
- Evaluates the *actual generated runtime code* via `new Function` against the mock DOM
- Verifies the exact reproduction case (`data-a="1" data-b="2"`) plus aria, class, mixed attributes, and 3+ data attributes
- Confirmed: the test **fails with the old code** (4/5 tests fail) and **passes with the fix** (5/5 pass)

### Why you made them, and:

The `enableAttributePassing` runtime code iterated over `parent.attributes` (a live `NamedNodeMap`) while calling `parent.removeAttribute()` inside the loop. Since `NamedNodeMap` is a live collection, removing an attribute shrinks it mid-iteration, causing subsequent attributes to be skipped.

### Any other useful context:

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
