### PR TITLE
refactor: added `command` property

### DIFF
--- a/.changeset/witty-poems-clean.md
+++ b/.changeset/witty-poems-clean.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+feat(`button`): added `command` property

--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -355,6 +355,7 @@ export declare namespace JSX {
 
   interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
     autofocus?: boolean;
+    command?: string;
     disabled?: boolean;
     form?: string;
     formaction?: string;
@@ -365,7 +366,6 @@ export declare namespace JSX {
     name?: string;
     type?: 'submit' | 'reset' | 'button';
     value?: string;
-    command?: string;
 
     // camelcase
     formAction?: string;

--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -365,6 +365,7 @@ export declare namespace JSX {
     name?: string;
     type?: 'submit' | 'reset' | 'button';
     value?: string;
+    command?: string;
 
     // camelcase
     formAction?: string;

--- a/packages/core/src/helpers/is-html-attribute.ts
+++ b/packages/core/src/helpers/is-html-attribute.ts
@@ -75,6 +75,7 @@ export const htmlElementAttributes: { [key: string]: string[] } = {
   body: ['alink', 'background', 'bgcolor', 'link', 'text', 'vlink'],
   br: ['clear'],
   button: [
+    'command',
     'disabled',
     'form',
     'formaction',
@@ -85,7 +86,6 @@ export const htmlElementAttributes: { [key: string]: string[] } = {
     'name',
     'type',
     'value',
-    'command',
   ],
   canvas: ['height', 'width'],
   caption: ['align'],

--- a/packages/core/src/helpers/is-html-attribute.ts
+++ b/packages/core/src/helpers/is-html-attribute.ts
@@ -85,6 +85,7 @@ export const htmlElementAttributes: { [key: string]: string[] } = {
     'name',
     'type',
     'value',
+    'command',
   ],
   canvas: ['height', 'width'],
   caption: ['align'],


### PR DESCRIPTION
## Description

Please provide the following information:

- What changes you made:

Added entires of new `command` property on `button` HTML element.

- Why you made them, and:

To keep up with the Web Standards development.

- Any other useful context:

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
