### PR TITLE
refactor: added `popover` property

### DIFF
--- a/.changeset/ninety-seahorses-swim.md
+++ b/.changeset/ninety-seahorses-swim.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+feat: added global `popover` property

--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -260,13 +260,13 @@ export declare namespace JSX {
     hidden?: boolean;
     id?: string;
     lang?: string;
+    popover?: 'auto' | 'hint' | 'manual' | '';
     spellcheck?: boolean;
     style?: CSS;
     css?: CSS | { [key: string]: CSS | undefined };
     tabindex?: number | string;
     title?: string;
     translate?: 'yes' | 'no';
-    popover?: 'auto' | 'hint' | 'manual' | '' | boolean;
 
     // RDFa Attributes
     about?: string;

--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -266,6 +266,7 @@ export declare namespace JSX {
     tabindex?: number | string;
     title?: string;
     translate?: 'yes' | 'no';
+    popover?: 'auto' | 'hint' | 'manual' | '' | boolean;
 
     // RDFa Attributes
     about?: string;

--- a/packages/core/src/helpers/is-html-attribute.ts
+++ b/packages/core/src/helpers/is-html-attribute.ts
@@ -19,6 +19,7 @@ export const htmlElementAttributes: { [key: string]: string[] } = {
     'itemtype',
     'lang',
     'nonce',
+    'popover',
     'slot',
     'spellcheck',
     'style',


### PR DESCRIPTION
## Description

Please provide the following information:

- What changes you made:

Added entires of new global `popover` property.

- Why you made them, and:

To keep up with the Web Standards development.

- Any other useful context:

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
