### PR TITLE
fix(stencil): TS error on attribute passing

### DIFF
--- a/.changeset/cuddly-candles-approve.md
+++ b/.changeset/cuddly-candles-approve.md
@@ -2,4 +2,4 @@
 '@builder.io/mitosis': patch
 ---
 
-fix(Stencil): TypeScript error in attribute passing removals
+fix(Stencil): TypeScript error in attribute passings

--- a/.changeset/cuddly-candles-approve.md
+++ b/.changeset/cuddly-candles-approve.md
@@ -2,4 +2,4 @@
 '@builder.io/mitosis': patch
 ---
 
-fix(Angular & Stencil): TypeScript error in attribute passing removals
+fix(Stencil): TypeScript error in attribute passing removals

--- a/.changeset/cuddly-candles-approve.md
+++ b/.changeset/cuddly-candles-approve.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/mitosis': patch
+---
+
+fix(Angular & Stencil): TypeScript error in attribute passing removals

--- a/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.import.test.ts.snap
@@ -3700,7 +3700,7 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -3786,7 +3786,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -12073,7 +12073,7 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -12162,7 +12162,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (

--- a/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.mapper.test.ts.snap
@@ -3752,7 +3752,7 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -3839,7 +3839,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -12265,7 +12265,7 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -12355,7 +12355,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (

--- a/packages/core/src/__tests__/__snapshots__/angular.signals.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.signals.test.ts.snap
@@ -3285,7 +3285,7 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -3369,7 +3369,7 @@ export class BasicRefAttributePassingCustomRefComponent
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -10466,7 +10466,7 @@ export class BasicRefAttributePassingComponent implements AfterViewInit {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -10550,7 +10550,7 @@ export class BasicRefAttributePassingCustomRefComponent
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (

--- a/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.state.test.ts.snap
@@ -3849,7 +3849,7 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -3935,7 +3935,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -12548,7 +12548,7 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -12637,7 +12637,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (

--- a/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.styles.test.ts.snap
@@ -3365,7 +3365,7 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -3444,7 +3444,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -10842,7 +10842,7 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -10924,7 +10924,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (

--- a/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/angular.test.ts.snap
@@ -7050,7 +7050,7 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -7138,7 +7138,7 @@ export default class BasicRefAttributePassingComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -7217,7 +7217,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -7298,7 +7298,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   private enableAttributePassing(element, customElementSelector) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -22921,7 +22921,7 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -23012,7 +23012,7 @@ export default class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -23094,7 +23094,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -23178,7 +23178,7 @@ export default class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (

--- a/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/stencil.test.ts.snap
@@ -2373,7 +2373,7 @@ export class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -2451,7 +2451,7 @@ export class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -6995,7 +6995,7 @@ export class BasicRefAttributePassingComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (
@@ -7073,7 +7073,7 @@ export class BasicRefAttributePassingCustomRefComponent {
   ) {
     const parent = element?.closest(customElementSelector);
     if (element && parent) {
-      const attributes = [...parent.attributes];
+      const attributes = Array.from(parent.attributes);
       for (let i = 0; i < attributes.length; i++) {
         const attr = attributes[i];
         if (

--- a/packages/core/src/helpers/web-components/attribute-passing.ts
+++ b/packages/core/src/helpers/web-components/attribute-passing.ts
@@ -16,7 +16,7 @@ export const getAttributePassingString = (typescript?: boolean) => {
 ` +
     '  const parent = element?.closest(customElementSelector);\n' +
     '  if (element && parent) {\n' +
-    '    const attributes = [...parent.attributes];\n' +
+    '    const attributes = Array.from(parent.attributes);\n' +
     '    for (let i = 0; i < attributes.length; i++) {\n' +
     '      const attr = attributes[i];\n' +
     "      if (attr && (attr.name.startsWith('data-') || attr.name.startsWith('aria-'))) {\n" +


### PR DESCRIPTION
## Description

Please provide the following information:

### What changes you made

Changed `[...parent.attributes]` → `Array.from(parent.attributes)`. `Array.from` is correctly typed to accept array-like objects (which `NamedNodeMap` is) without needing `DOM.Iterable`.

### Why you made them

In `packages/core/src/helpers/web-components/attribute-passing.ts`, the generated code uses `[...parent.attributes]` (spread on `NamedNodeMap`). TypeScript requires `DOM.Iterable` in the `lib` compiler option for this to type-check.

### Any other useful context

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](../CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `yarn fmt:prettier`.
- [x] update all snapshots (in core & CLI): from the root, run `yarn test:update`
- [x] add Changeset entry: from the root, run `yarn g:changeset` and follow the CLI instructions. Alternatively, use the Changeset Github Bot to create the file.
